### PR TITLE
Fix SSL certificate verification for printers using self-signed HTTPS

### DIFF
--- a/custom_components/epson_workforce/api.py
+++ b/custom_components/epson_workforce/api.py
@@ -51,5 +51,5 @@ class EpsonWorkForceAPI:
 
             self.soup = BeautifulSoup(data, "html.parser")
             self.available = True
-        except Exception as ex:
+        except Exception:
             self.available = False

--- a/custom_components/epson_workforce/api.py
+++ b/custom_components/epson_workforce/api.py
@@ -1,5 +1,6 @@
 """Epson WorkForce API"""
 
+import ssl
 import urllib.request
 
 from bs4 import BeautifulSoup
@@ -43,11 +44,12 @@ class EpsonWorkForceAPI:
     def update(self):
         """Fetch the HTML page."""
         try:
-            with urllib.request.urlopen(self._resource) as response:
+            context = ssl._create_unverified_context()
+            with urllib.request.urlopen(self._resource, context=context) as response:
                 data = response.read()
                 response.close()
 
             self.soup = BeautifulSoup(data, "html.parser")
             self.available = True
-        except Exception:
+        except Exception as ex:
             self.available = False


### PR DESCRIPTION
### Summary

This PR fixes a bug when accessing Epson printers that serve their status page over HTTPS with a self-signed certificate. The existing implementation using `urllib.request.urlopen()` would fail due to SSL certificate verification.

### Changes

- Added an SSL context to `urllib.request.urlopen()` using `ssl._create_unverified_context()` to skip certificate verification for self-signed certs.
- Ensures `update()` can successfully fetch data from printers accessible only via HTTPS with invalid or self-signed certificates.

### Context

By default/due to firmware upgrades, **EPSON is forcing HTTP to HTTPS**. While this HTTPS enforcement can be disabled under the printer's **Web UI**, users need to:
1. Log in as an **Administrator**.
2. Navigate to **Advanced Settings**.
3. Go to the **SSL Settings** and disable the **Redirect to HTTPS** setting.

This would allow the printer to accept **HTTP connections** again, removing the need to bypass SSL verification. However, this PR allows users to interact with the printer over **HTTPS**, even when using a self-signed certificate.

### Related

Fixes  partially the issue https://github.com/lymanepp/ha-epson-workforce/issues/8
