### PR TITLE
Refactor parsing to be more testable and compatible with more Epson printers

### DIFF
--- a/custom_components/epson_workforce/api.py
+++ b/custom_components/epson_workforce/api.py
@@ -33,7 +33,6 @@ class EpsonWorkForceAPI:
 
         self.update()
 
-    # Public properties
     @property
     def model(self) -> str:
         """Returns the model name of the printer."""
@@ -46,9 +45,10 @@ class EpsonWorkForceAPI:
         self._ensure_parsed()
         return (self._data or {}).get("mac_address")
 
-    # Public fetch
     def update(self) -> None:
-        """Fetch and parse the HTML page from the device (rebuilds parser + resets cache)."""
+        """
+        Fetch and parse the HTML page from the device (rebuilds parser + resets cache).
+        """
         try:
             context = ssl._create_unverified_context()
             with urllib.request.urlopen(self._resource, context=context) as response:

--- a/custom_components/epson_workforce/api.py
+++ b/custom_components/epson_workforce/api.py
@@ -1,4 +1,4 @@
-"""Epson WorkForce API — same public API, backed by a lightweight EpsonHTMLParser."""
+"""Epson WorkForce API."""
 
 from __future__ import annotations
 
@@ -6,19 +6,10 @@ import ssl
 from typing import Any
 import urllib.request
 
-from .parser import EpsonHTMLParser  # Adjust the import path as needed
+from .parser import EpsonHTMLParser
 
 
 class EpsonWorkForceAPI:
-    """
-    Public API compatibility:
-      - __init__(ip, path)
-      - update()
-      - get_sensor_value(sensor) -> int|str|None
-      - properties: model, mac_address
-      - attributes: available
-    """
-
     def __init__(self, ip: str, path: str):
         self._resource = "http://" + ip + path
         self.available: bool = True

--- a/custom_components/epson_workforce/api.py
+++ b/custom_components/epson_workforce/api.py
@@ -58,28 +58,14 @@ class EpsonWorkForceAPI:
         self._ensure_parsed()
         data = self._data or {}
 
-        s = (sensor or "").strip().lower()
-        if s == "printer_status":
+        if sensor == "printer_status":
             return data.get("printer_status") or "Unknown"
 
-        if s == "clean":
+        if sensor == "clean":
             return data.get("maintenance_box")
 
-        label_map = {
-            "black": "BK",
-            "cyan": "C",
-            "magenta": "M",
-            "yellow": "Y",
-            "photoblack": "PB",
-            "lightcyan": "LC",
-            "lightmagenta": "LM",
-            "gray": "GY",
-        }
-        if s in label_map:
-            inks: dict[str, int] = data.get("inks") or {}
-            return inks.get(label_map[s])
-
-        return None
+        inks: dict[str, int] = data.get("inks") or {}
+        return inks.get(sensor)
 
     def _ensure_parsed(self) -> None:
         if self._data is not None:
@@ -89,5 +75,4 @@ class EpsonWorkForceAPI:
         try:
             self._data = self._parser.parse()
         except Exception:
-            # Leave _data as None to keep Unknown/None behavior
             self._data = {}

--- a/custom_components/epson_workforce/api.py
+++ b/custom_components/epson_workforce/api.py
@@ -74,7 +74,6 @@ class EpsonWorkForceAPI:
             "lightcyan": "LC",
             "lightmagenta": "LM",
             "gray": "GY",
-            "grey": "GY",
         }
         if s in label_map:
             inks: dict[str, int] = data.get("inks") or {}

--- a/custom_components/epson_workforce/api.py
+++ b/custom_components/epson_workforce/api.py
@@ -1,173 +1,103 @@
-"""Epson WorkForce API"""
+"""Epson WorkForce API — same public API, backed by a lightweight EpsonHTMLParser."""
+
+from __future__ import annotations
 
 import ssl
+from typing import Any
 import urllib.request
 
-from bs4 import BeautifulSoup
-
-# Maximum status length before truncating trailing period
-MAX_STATUS_LENGTH = 30
-
-LEVEL_SENSOR_TO_DIV = {
-    "black": ("clrname", "BK"),
-    "photoblack": ("clrname", "PB"),
-    "magenta": ("clrname", "M"),
-    "cyan": ("clrname", "C"),
-    "yellow": ("clrname", "Y"),
-    "lightcyan": ("clrname", "LC"),
-    "lightmagenta": ("clrname", "LM"),
-    "clean": ("mbicn", "Waste"),
-}
+from .parser import EpsonHTMLParser  # Adjust the import path as needed
 
 
 class EpsonWorkForceAPI:
+    """
+    Public API compatibility:
+      - __init__(ip, path)
+      - update()
+      - get_sensor_value(sensor) -> int|str|None
+      - properties: model, mac_address
+      - attributes: available
+    """
+
     def __init__(self, ip: str, path: str):
-        """Initialize the link to the printer status page."""
         self._resource = "http://" + ip + path
-        self.available = True
-        self.soup = None
-        self._model = None
-        self._mac_address = None
+        self.available: bool = True
+
+        # Internal
+        self._parser: EpsonHTMLParser | None = None
+        self._data: dict[str, Any] | None = None  # parsed dict cache
+
+        # Defaults
+        self._model: str | None = None
+        self._mac: str | None = None
+
         self.update()
 
-    def get_sensor_value(self, sensor: str) -> int | str | None:
-        """To make it the user easier to configure the cartridge type."""
-        # Handle printer status sensor separately
-        if sensor == "printer_status":
-            return self._get_printer_status()
-
-        # Handle ink level sensors
-        if not (sensor_info := LEVEL_SENSOR_TO_DIV.get(sensor)):
-            return None
-
-        if not self.soup:
-            return None
-
-        div_name, div_text = sensor_info
-        try:
-            for li in self.soup.find_all("li", class_="tank"):
-                div = li.find("div", class_=div_name)
-
-                if div and div_text in (div.contents[0], "Waste"):
-                    return int(li.find("div", class_="tank").findChild()["height"]) * 2
-        except Exception:
-            pass
-
-        return None
+    # Public properties
+    @property
+    def model(self) -> str:
+        """Returns the model name of the printer."""
+        self._ensure_parsed()
+        return (self._data or {}).get("model") or "WorkForce Printer"
 
     @property
-    def model(self):
-        """Return the printer model if available."""
-        return self._model or "WorkForce Printer"
+    def mac_address(self) -> str | None:
+        """Returns the MAC address of the device if available."""
+        self._ensure_parsed()
+        return (self._data or {}).get("mac_address")
 
-    @property
-    def mac_address(self):
-        """Return the printer MAC address if available."""
-        return self._mac_address
-
-    def _extract_device_info(self):
-        """Extract device information from the HTML page."""
-        if not self.soup:
-            return
-
-        # Try to find model information
-        try:
-            # Look for model in title or other common locations
-            title = self.soup.find("title")
-            if title and title.text:
-                title_text = title.text.strip()
-                # Extract model from title (e.g., "ET-8500 Series")
-                if title_text and title_text != "":
-                    self._model = f"Epson {title_text}"
-        except Exception:
-            pass
-
-        try:
-            # Look for MAC address in the text content
-            all_text = self.soup.get_text()
-            lines = [line.strip() for line in all_text.split('\n') if line.strip()]
-
-            for line in lines:
-                if 'MAC Address' in line and ':' in line:
-                    # Extract MAC address
-                    mac_part = line.split('MAC Address')[1].strip()
-                    if mac_part.startswith(':'):
-                        mac_part = mac_part[1:].strip()
-                    self._mac_address = mac_part
-                    break
-        except Exception:
-            pass
-
-    def _clean_status(self, status: str | None) -> str | None:
-        """Clean up status text by removing trailing periods from short statuses."""
-        if not status:
-            return None
-        if len(status) < MAX_STATUS_LENGTH and status.endswith('.'):
-            status = status[:-1]
-        return status
-
-    def _get_fieldset_status(self) -> str | None:
-        """Get status from fieldset structure: <fieldset id="PRT_STATUS">
-        <ul>...</ul></fieldset>"""
-        if not self.soup:
-            return None
-
-        fieldset = self.soup.find("fieldset", id="PRT_STATUS")
-        if not fieldset:
-            return None
-
-        ul = fieldset.find("ul")
-        if not ul:
-            return None
-
-        status = ul.get_text(strip=True)
-        return self._clean_status(status)
-
-    def _get_information_div_status(self):
-        """Get status from information div structure: <div class="information">
-        <p class="clearfix"><span>Available.</span></p></div>"""
-        info_div = self.soup.find("div", class_="information")
-        if not info_div:
-            return None
-
-        # Prefer a <span> inside <p.clearfix>, else any <span> within .information
-        p = info_div.find("p", class_="clearfix")
-        span = (p.find("span") if p else None) or info_div.find("span")
-        if not span:
-            return None
-
-        status = span.get_text(strip=True)
-        return self._clean_status(status)
-
-    def _get_printer_status(self) -> str:
-        """Get printer status using multiple parsing strategies."""
-        try:
-            # Try fieldset structure first: <fieldset id="PRT_STATUS">
-            # <ul>...</ul></fieldset>
-            status = self._get_fieldset_status()
-            if status:
-                return status
-
-            # Information div structure: <div class="information"><p class="clearfix">
-            # <span>Available.</span></p></div>
-            status = self._get_information_div_status()
-            if status:
-                return status
-        except Exception:
-            return "Unknown"
-        else:
-            return "Unknown"
-
-    def update(self):
-        """Fetch the HTML page."""
+    # Public fetch
+    def update(self) -> None:
+        """Fetch and parse the HTML page from the device (rebuilds parser + resets cache)."""
         try:
             context = ssl._create_unverified_context()
             with urllib.request.urlopen(self._resource, context=context) as response:
-                data = response.read()
-                response.close()
-
-            self.soup = BeautifulSoup(data, "html.parser")
+                data_bytes = response.read()
+            html_text = data_bytes.decode("utf-8", errors="ignore")
+            self._parser = EpsonHTMLParser(html_text, source=self._resource)
             self.available = True
-            self._extract_device_info()
+            self._data = None  # invalidate cache
         except Exception:
             self.available = False
+            self._parser = None
+            self._data = None
+
+    def get_sensor_value(self, sensor: str) -> int | str | None:
+        """Retrieves the value of a specified sensor from the parsed printer data."""
+        self._ensure_parsed()
+        data = self._data or {}
+
+        s = (sensor or "").strip().lower()
+        if s == "printer_status":
+            return data.get("printer_status") or "Unknown"
+
+        if s == "clean":
+            return data.get("maintenance_box")
+
+        label_map = {
+            "black": "BK",
+            "cyan": "C",
+            "magenta": "M",
+            "yellow": "Y",
+            "photoblack": "PB",
+            "lightcyan": "LC",
+            "lightmagenta": "LM",
+            "gray": "GY",
+            "grey": "GY",
+        }
+        if s in label_map:
+            inks: dict[str, int] = data.get("inks") or {}
+            return inks.get(label_map[s])
+
+        return None
+
+    def _ensure_parsed(self) -> None:
+        if self._data is not None:
+            return
+        if not self._parser:
+            return
+        try:
+            self._data = self._parser.parse()
+        except Exception:
+            # Leave _data as None to keep Unknown/None behavior
+            self._data = {}

--- a/custom_components/epson_workforce/parser.py
+++ b/custom_components/epson_workforce/parser.py
@@ -1,0 +1,213 @@
+"""Epson WorkForce API — same public API, backed by a lightweight EpsonHTMLParser."""
+
+from __future__ import annotations
+
+import html as html_lib
+import re
+from typing import Any
+
+from bs4 import BeautifulSoup
+from bs4.element import NavigableString, Tag
+
+
+# ----------------------------
+# Lightweight HTML page parser
+# ----------------------------
+def _classes(node: Tag) -> list[str]:
+    return list(node.get("class") or [])
+
+
+def _height_from_style(node: Tag) -> int | None:
+    style_val = node.get("style")
+    if isinstance(style_val, str):
+        style = style_val.lower()
+    elif isinstance(style_val, list):
+        style = " ".join(style_val).lower()
+    else:
+        return None
+
+    m = re.search(r"height\s*:\s*(\d+)", style)
+    return int(m.group(1)) if m else None
+
+
+def _clean_key(t: str) -> str:
+    t = t.replace("\xa0:", "").replace(" :", ":").strip()
+    if t.endswith(":"):
+        t = t[:-1].strip()
+    return t
+
+
+class EpsonHTMLParser:
+    """
+    Minimal, robust parser for Epson status pages across multiple models/skins.
+    - Model from <title> or .header text
+    - Status from fieldsets like #PRT_STATUS / #SCN_STATUS, or .information span
+    - Ink tanks from <li class="tank"> (label in .clrname, bar in inner <div class="tank"> <img height=...>)
+    - Maintenance/waste row detected via <div class="mbicn">
+    - Network & Wi-Fi Direct tables parsed as key/value pairs
+    """
+
+    def __init__(self, html_text: str, source: str = ""):
+        self.source = source
+        self.soup: BeautifulSoup = BeautifulSoup(html_text, "html.parser")
+
+    def parse(self) -> dict[str, Any]:
+        model = self._parse_model()
+        statuses = self._parse_statuses()
+        inks, maintenance = self._parse_inks_and_maintenance()
+        network = self._parse_table_by_container_id("info-network")
+        wifi_direct = self._parse_table_by_container_id("info-wfd")
+        mac = network.get("MAC Address") or self._extract_mac_from_text()
+
+        out: dict[str, Any] = {
+            "source": self.source or model,
+            "model": model,
+            **statuses,  # e.g., {"printer_status": "...", "scanner_status": "..."}
+            "inks": inks,
+            "maintenance_box": maintenance,
+            "network": network,
+        }
+        if wifi_direct:
+            out["wifi_direct"] = wifi_direct
+        if mac:
+            out["mac_address"] = mac
+        return out
+
+    # --- model / status ---
+    def _parse_model(self) -> str | None:
+        t = self.soup.find("title")
+        if isinstance(t, Tag) and t.text.strip():
+            return f"Epson {t.text.strip()}"
+        head_span = self.soup.find("span", class_="header")
+        if isinstance(head_span, Tag) and head_span.get_text(strip=True):
+            return f"Epson {head_span.get_text(strip=True)}"
+        return None
+
+    def _parse_statuses(self) -> dict[str, str | None]:
+        out: dict[str, str | None] = {}
+        # Known fieldsets
+        for fid, key in (
+            ("PRT_STATUS", "printer_status"),
+            ("SCN_STATUS", "scanner_status"),
+        ):
+            fs = self.soup.find("fieldset", id=fid)
+            if isinstance(fs, Tag):
+                txt = fs.get_text(" ", strip=True)
+                out[key] = self._clean_status(txt)
+        # Fallback for printer status
+        if "printer_status" not in out or not out["printer_status"]:
+            info = self.soup.find("div", class_="information")
+            if isinstance(info, Tag):
+                span = info.find("span")
+                if isinstance(span, Tag):
+                    out["printer_status"] = self._clean_status(
+                        span.get_text(strip=True)
+                    )
+        return out
+
+    @staticmethod
+    def _clean_status(s: str | None) -> str | None:
+        if not s:
+            return None
+        s = s.strip()
+        s = re.sub(
+            r"^(?:printer|scanner)\s+status\s*[:\-]?\s*", "", s, flags=re.IGNORECASE
+        )
+        if len(s) <= 40 and s.endswith("."):
+            s = s[:-1]
+        return s or None
+
+    # --- inks / maintenance ---
+    def _parse_inks_and_maintenance(self) -> tuple[dict[str, int], int | None]:
+        inks: dict[str, int] = {}
+        maintenance: int | None = None
+
+        for li in self.soup.select("li.tank"):
+            # if not isinstance(li, Tag):
+            #    continue
+            # label
+            label = None
+            for d in li.find_all("div"):
+                if not isinstance(d, Tag):
+                    continue
+                if any(c.lower() == "clrname" for c in _classes(d)):
+                    txt = d.get_text(strip=True)
+                    if txt:
+                        label = txt.upper()
+                        break
+
+            # maintenance row?
+            is_maintenance = any(
+                any(c.lower() == "mbicn" for c in _classes(d))
+                for d in li.find_all("div")
+                if isinstance(d, Tag)
+            )
+
+            # bar height
+            height_px = self._li_bar_height(li)
+            if height_px is None:
+                continue
+            pct = max(0, min(100, height_px * 2))
+
+            if is_maintenance:
+                maintenance = pct
+            elif label:
+                inks[label] = pct
+
+        return inks, maintenance
+
+    def _li_bar_height(self, li: Tag) -> int | None:
+        # find inner div.tank (the visual container)
+        bar_div = None
+        for d in li.find_all("div"):
+            if not isinstance(d, Tag):
+                continue
+            if any(c.lower() == "tank" for c in _classes(d)):
+                bar_div = d
+                break
+        if bar_div is None:
+            return None
+        # prefer <img class="color"> then any <img>
+        img = bar_div.find("img", class_="color") or bar_div.find("img")
+        if isinstance(img, Tag):
+            h = img.get("height")
+            if isinstance(h, str) and h.isdigit():
+                return int(h)
+            h2 = _height_from_style(img)
+            if h2 is not None:
+                return h2
+        # fallback: any descendant with inline height
+        for desc in bar_div.descendants:
+            if isinstance(desc, Tag):
+                h3 = _height_from_style(desc)
+                if h3 is not None:
+                    return h3
+        return None
+
+    # --- key/value tables ---
+    def _parse_table_by_container_id(self, container_id: str) -> dict[str, str]:
+        data: dict[str, str] = {}
+        root = self.soup.find(id=container_id)
+        if not isinstance(root, Tag):
+            return data
+        for tr in root.find_all("tr"):
+            if not isinstance(tr, Tag):
+                continue
+            td_key = tr.find(
+                "td", class_=lambda c: isinstance(c, str) and "item-key" in c
+            )
+            td_val = tr.find(
+                "td", class_=lambda c: isinstance(c, str) and "item-value" in c
+            )
+            if isinstance(td_key, Tag) and isinstance(td_val, Tag):
+                key = _clean_key(td_key.get_text(" ", strip=True))
+                val = td_val.get_text(" ", strip=True)
+                if key:
+                    data[key] = val
+        return data
+
+    # --- misc ---
+    def _extract_mac_from_text(self) -> str | None:
+        txt = self.soup.get_text(" ", strip=True)
+        m = re.search(r"\b([0-9A-F]{2}:){5}[0-9A-F]{2}\b", txt, flags=re.IGNORECASE)
+        return m.group(0) if m else None

--- a/custom_components/epson_workforce/parser.py
+++ b/custom_components/epson_workforce/parser.py
@@ -8,6 +8,8 @@ from typing import Any
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 
+MAX_STATUS_LENGTH = 40
+
 
 # ----------------------------
 # Lightweight HTML page parser
@@ -103,7 +105,7 @@ class EpsonHTMLParser:
         s = re.sub(
             r"^(?:printer|scanner)\s+status\s*[:\-]?\s*", "", s, flags=re.IGNORECASE
         )
-        if len(s) <= 40 and s.endswith("."):
+        if len(s) <= MAX_STATUS_LENGTH and s.endswith("."):
             s = s[:-1]
         return s or None
 

--- a/custom_components/epson_workforce/sensor.py
+++ b/custom_components/epson_workforce/sensor.py
@@ -36,6 +36,12 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
+        key="gray",
+        name="Ink level Gray",
+        icon="mdi:water",
+        native_unit_of_measurement=PERCENTAGE,
+    ),
+    SensorEntityDescription(  # type: ignore[call-arg]
         key="magenta",
         name="Ink level Magenta",
         icon="mdi:water",
@@ -104,7 +110,7 @@ async def async_setup_entry(
         "Detected %d available sensors for printer %s: %s",
         len(available_sensors),
         entry.data["host"],
-        ", ".join(available_sensors)
+        ", ".join(available_sensors),
     )
 
     # Create only sensors that are available on this printer

--- a/custom_components/epson_workforce/sensor.py
+++ b/custom_components/epson_workforce/sensor.py
@@ -24,49 +24,49 @@ _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(  # type: ignore[call-arg]
-        key="black",
+        key="BK",
         name="Ink level Black",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
-        key="photoblack",
+        key="PB",
         name="Ink level Photoblack",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
-        key="gray",
+        key="GY",
         name="Ink level Gray",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
-        key="magenta",
+        key="M",
         name="Ink level Magenta",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
-        key="cyan",
+        key="C",
         name="Ink level Cyan",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
-        key="yellow",
+        key="Y",
         name="Ink level Yellow",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
-        key="lightcyan",
+        key="LC",
         name="Ink level Light Cyan",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
-        key="lightmagenta",
+        key="LM",
         name="Ink level Light Magenta",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
@@ -215,6 +215,7 @@ class EpsonPrinterCartridge(CoordinatorEntity, SensorEntity):
         """Return a unique ID for this sensor."""
         return f"epson_workforce_{self._host_clean}_{self.entity_description.key}"
 
+    @property
     def native_value(self):
         """Return the state of the device."""
         return self.coordinator.api.get_sensor_value(self.entity_description.key)

--- a/tests/fixtures/L6270.html
+++ b/tests/fixtures/L6270.html
@@ -1,0 +1,3729 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN " "http://www.w3.org/TR/html4/strict.dtd">
+<!-- saved from url=(0055)https://192.168.0.75/PRESENTATION/HTML/TOP/PRTINFO.HTML -->
+<html data-lt-installed="true" style="--vsc-domain: &quot;192.168.0.75&quot;;"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<meta name="Author" content="SEIKO EPSON">
+<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0">
+<meta name="format-detection" content="telephone=no">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<script type="text/javascript"><!--
+var current = new Date();
+document.write("<link rel='stylesheet' type='text/css' href='../../STYLE/SMT.CSS&tm=" + current.getTime() + "' media='only screen and (max-device-width:800px)'>");
+document.write("<link rel='stylesheet' type='text/css' href='../../STYLE/PC.CSS&tm=" + current.getTime() + "' media='only screen and (min-device-width:801px)'>");
+document.write("<!--[if IE ]>" +"<link rel='stylesheet' type='text/css' href='../../STYLE/PC.CSS&tm=" + current.getTime() + "'>" +"<![endif]-->");
+// --></script><link rel="stylesheet" type="text/css" href="https://192.168.0.75/PRESENTATION/STYLE/SMT.CSS&amp;tm=1756914852442" media="only screen and (max-device-width:800px)"><link rel="stylesheet" type="text/css" href="https://192.168.0.75/PRESENTATION/STYLE/PC.CSS&amp;tm=1756914852442" media="only screen and (min-device-width:801px)"><!--[if IE ]><link rel='stylesheet' type='text/css' href='../../STYLE/PC.CSS&tm=1756914852442'><![endif]-->
+<noscript>
+<link rel='stylesheet' type='text/css' href='../../STYLE/SMT.CSS' media='only screen and (max-device-width:800px)'>
+<link rel='stylesheet' type='text/css' href='../../STYLE/PC.CSS' media='only screen and (min-device-width:801px)'>
+<!--[if IE ]>
+<link rel='stylesheet' type='text/css' href='../../STYLE/PC.CSS'>
+<![endif]-->
+</noscript>
+<title>L6270 Series</title>
+<script type="text/javascript" src="https://192.168.0.75/PRESENTATION/SCRIPT/MENT.JS"></script>
+<style type="text/css" id="tts-styles">[data-tts-block-id].tts-active {background: rgba(206, 225, 255, 0.9) !important;} [data-tts-sentence-id].tts-active {background: rgba(0, 89, 191, 0.7) !important;}</style><style class="automa-element-selector">@font-face { font-family: "Inter var"; font-weight: 100 900; font-display: swap; font-style: normal; font-named-instance: "Regular"; src: url("chrome-extension://infppggnoaenmfagbfknfkancpbljcca/Inter-roman-latin.var.woff2") format("woff2") }
+.automa-element-selector { direction: ltr } 
+ [automa-isDragging] { user-select: none } 
+ [automa-el-list] {outline: 2px dashed #6366f1;}</style></head>
+<body onload="(function(){setTimeout(function(){if(window.pageYOffset==0){window.scrollTo(0,1);}},100);})()" onunload="(function(){})()">
+<div class="wrap">
+<div class="header">
+<h1 class="font-size-14em">
+<img class="logo" src="https://192.168.0.75/PRESENTATION/IMAGE/EPSONLOGO.PNG" width="83" height="21" alt="EPSON">
+<img class="separatpr" src="https://192.168.0.75/PRESENTATION/IMAGE/SEPARATOR.PNG" width="2" height="58" alt="">
+<span class="separatpr"></span>
+<span class="header">L6270 Series</span>
+</h1>
+</div>
+<div class="section">
+<h2><img class="link-title" src="https://192.168.0.75/PRESENTATION/IMAGE/PRTINFO_ILL.PNG" width="48" height="48" alt="">Product Status</h2>
+<table class="navi"><tbody><tr>
+<td id="tab-item-main" class="tab-item-main-on-sprtwfd" onclick="info_main_sprtwfd()">Basic</td>
+<td id="tab-item-network" class="tab-item-network-off-sprtwfd" onclick="info_network_sprtwfd()">Network</td>
+<td id="tab-item-wfd" class="tab-item-wfd-off" onclick="info_wfd()">Wi-Fi Direct</td>
+</tr></tbody></table>
+<div id="info-main" style="display: block;">
+<div class="information-first">
+<form method="get" name="form_select_language" action="https://192.168.0.75/PRESENTATION/HTML/TOP/PRTINFO.HTML">
+<select class="list-full text" name="SEL_LANGB" onchange="return document.form_select_language.submit();">
+<option value="1" selected="">English</option>
+<option value="5">Español</option>
+<option value="6">Português</option>
+<option value="2">Français</option>
+</select>
+</form>
+</div>
+<div class="information">
+<fieldset id="PRT_STATUS" class="information-only clearfix"><legend class="key">Printer Status</legend>
+<ul class="clearfix"><li><div class="preserve-white-space">Available.</div></li></ul></fieldset>
+<div id="ELSE_STATUS" style="display: none;"><fieldset class="information-last clearfix"><legend class="key">Other Status</legend>
+<ul class="clearfix"><li><noscript><div>Enable your browser's JavaScript setting.</div></noscript></li>
+</ul></fieldset></div>
+</div>
+<script type="text/javascript">
+<!--$N
+HideElseStatus();
+//-->$N
+</script>
+<div class="information-last clearfix">
+<ul class="inksection">
+<li class="tank">
+<div class="tank">
+<img class="color" src="https://192.168.0.75/PRESENTATION/IMAGE/Ink_K.PNG" height="34" style="">
+</div>
+<div class="clrname">BK</div>
+</li><!--
+--><li class="tank">
+<div class="tank">
+<img class="color" src="https://192.168.0.75/PRESENTATION/IMAGE/Ink_C.PNG" height="40" style="">
+</div>
+<div class="clrname">C</div>
+</li><!--
+--><li class="tank">
+<div class="tank">
+<img class="color" src="https://192.168.0.75/PRESENTATION/IMAGE/Ink_M.PNG" height="40" style="">
+</div>
+<div class="clrname">M</div>
+</li><!--
+--><li class="tank">
+<div class="tank">
+<img class="color" src="https://192.168.0.75/PRESENTATION/IMAGE/Ink_Y.PNG" height="40" style="">
+</div>
+<div class="clrname">Y</div>
+</li><!--
+--><li class="tank">
+<div class="tank">
+<img class="color" src="https://192.168.0.75/PRESENTATION/IMAGE/Ink_Waste.PNG" height="45" style="">
+</div>
+<div class="mbicn"><img src="https://192.168.0.75/PRESENTATION/IMAGE/Icn_Mb.PNG" height="18" width="18"></div>
+</li>
+</ul>
+</div>
+</div>
+<div id="info-network" style="display: none;">
+<table style="border-collapse: collapse; width: 100%;">
+<tbody><tr class="item clearfix"><td class="item-key"><bdi>Device Name</bdi>&nbsp;:</td><td class="item-value">EPSON7E2246</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Connection Status</bdi>&nbsp;:</td><td class="item-value">Wi-Fi-72Mbps</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Signal Strength</bdi>&nbsp;:</td><td class="item-value">Excellent</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Obtain IP Address</bdi>&nbsp;:</td><td class="item-value">Auto</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>IP Address</bdi>&nbsp;:</td><td class="item-value">192.168.0.75</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Subnet Mask</bdi>&nbsp;:</td><td class="item-value">255.255.255.0</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Default Gateway</bdi>&nbsp;:</td><td class="item-value">192.168.0.1</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>DNS Server Setting</bdi>&nbsp;:</td><td class="item-value">Auto</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Primary DNS Server</bdi>&nbsp;:</td><td class="item-value">192.168.0.17</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Secondary DNS Server</bdi>&nbsp;:</td><td class="item-value">1.1.1.1</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Proxy Server</bdi>&nbsp;:</td><td class="item-value">Do Not Use
+</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Wi-Fi Setup</bdi>&nbsp;:</td><td class="item-value">Epson iPrint</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>SSID</bdi>&nbsp;:</td><td class="item-value">eLeCtRoN-Lan-SD</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Security Level</bdi>&nbsp;:</td><td class="item-value">WPA3-SAE(AES)</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Password</bdi>&nbsp;:</td><td class="item-value">**********</td></tr>
+<tr class="item-last clearfix"><td class="item-key"><bdi>MAC Address</bdi>&nbsp;:</td><td class="item-value">68:55:D4:7E:22:46</td></tr>
+</tbody></table>
+</div>
+<div id="info-wfd" style="display: none;">
+<table style="border-collapse: collapse; width: 100%;">
+<tbody><tr class="item clearfix"><td class="item-key"><bdi>Device Name</bdi>&nbsp;:</td><td class="item-value">EPSON7E2246</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Connection Method</bdi>&nbsp;:</td><td class="item-value">Not Set</td></tr>
+</tbody></table>
+</div>
+</div>
+<ul class="with-padding clearfix">
+<li id="button-latest" class="list" style="display: block;"><a class="button" href="javascript:void(0)" onclick="javascript:update(); return false;">Refresh</a></li>
+<noscript><li class="list"><a class="button" href="./PRTINFO.HTML">Refresh</a></li></noscript>
+<li class="list-last"><a class="button" href="https://192.168.0.75/PRESENTATION/HTML/TOP/INDEX.html">Back to Main</a></li>
+</ul>
+<ul>
+<a class="license" target="_blank" href="https://192.168.0.75/PRESENTATION/ADVANCED/LICENSE/TOP">Software Licenses</a>
+</ul>
+</div>
+<script type="text/javascript">
+<!--
+initialize();
+//-->
+</script>
+
+<div id="automa-palette"><template shadowrootmode="open"><style>.tippy-box[data-animation=shift-toward-subtle][data-state=hidden]{opacity:0}.tippy-box[data-animation=shift-toward-subtle][data-state=hidden][data-placement^=top][data-state=hidden]{transform:translateY(-5px)}.tippy-box[data-animation=shift-toward-subtle][data-state=hidden][data-placement^=bottom][data-state=hidden]{transform:translateY(5px)}.tippy-box[data-animation=shift-toward-subtle][data-state=hidden][data-placement^=left][data-state=hidden]{transform:translateX(-5px)}.tippy-box[data-animation=shift-toward-subtle][data-state=hidden][data-placement^=right][data-state=hidden]{transform:translateX(5px)}
+
+.input-ui input[type='color'] {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+
+.root {
+  font-size: 16px;
+  z-index: 99999;
+  line-height: 1.5 !important;
+  font-family: 'Inter var', sans-serif;
+  font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+}
+.root-card:hover .drag-button {
+  transform: scale(1);
+}
+.drag-button {
+  transform: scale(0);
+  transition: transform 200ms ease-in-out;
+}
+.main-tab {
+  background-color: transparent !important;
+  padding: 0 !important;
+}
+.main-tab .ui-tab.is-active.fill {
+  --tw-bg-opacity: 1 !important;
+  background-color: rgb(var(--color-accent) / var(--tw-bg-opacity, 1)) !important;
+  --tw-text-opacity: 1 !important;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1)) !important;
+}
+
+
+.ui-tab[data-v-681b5d14] {
+  z-index: 1;
+  border-bottom-width: 2px;
+  border-color: transparent;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.ui-tab.small[data-v-681b5d14] {
+  padding: 8px;
+}
+.ui-tab.fill[data-v-681b5d14] {
+  border-radius: 8px;
+  border-bottom-width: 0px;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+.ui-tab.fill.small[data-v-681b5d14] {
+  padding: 8px;
+}
+.ui-tab.is-active[data-v-681b5d14] {
+  --tw-border-opacity: 1;
+  border-color: rgb(var(--color-accent) / var(--tw-border-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(39 39 42 / var(--tw-text-opacity, 1));
+}
+.ui-tab.is-active[data-v-681b5d14]:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(244 244 245 / var(--tw-border-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+.ui-tab.is-active.fill[data-v-681b5d14] {
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.05;
+}
+.ui-tab.is-active.fill[data-v-681b5d14]:is(.dark *) {
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.05;
+}
+.ui-tab.is-active[data-v-681b5d14] {
+  --tw-border-opacity: 1;
+  border-color: rgb(var(--color-accent) / var(--tw-border-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(39 39 42 / var(--tw-text-opacity, 1));
+}
+.ui-tab.is-active[data-v-681b5d14]:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(244 244 245 / var(--tw-border-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+
+.ui-tabs__indicator {
+  min-height: 24px;
+  min-width: 50px;
+  transition-duration: 200ms;
+  transition-property: transform, width;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+
+.button-loading {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+
+.ui-select__arrow {
+  top: 50%;
+  transform: translateY(-50%) rotate(90deg);
+}
+.ui-select option,
+.ui-select optgroup {
+  --tw-bg-opacity: 1;
+  background-color: rgb(244 244 245 / var(--tw-bg-opacity, 1));
+}
+.ui-select option:is(.dark *),
+.ui-select optgroup:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(63 63 70 / var(--tw-bg-opacity, 1));
+}
+
+
+.ui-switch[data-v-cc5de7b2] {
+  overflow: hidden;
+  transition: all 250ms ease;
+}
+.ui-switch[data-v-cc5de7b2]:active {
+  transform: scale(0.93);
+}
+.ui-switch__ball[data-v-cc5de7b2] {
+  transition: all 250ms ease;
+  left: 6px;
+}
+.ui-switch__background[data-v-cc5de7b2] {
+  transition: all 250ms ease;
+  margin-left: -100%;
+}
+.ui-switch:hover .ui-switch__ball[data-v-cc5de7b2] {
+  transform: scale(1.1);
+}
+.ui-switch input:focus ~ .ui-switch__ball[data-v-cc5de7b2] {
+  transform: scale(1.1);
+}
+.ui-switch input:checked ~ .ui-switch__ball[data-v-cc5de7b2]:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(24 24 27 / var(--tw-bg-opacity, 1));
+}
+.ui-switch input:checked ~ .ui-switch__ball[data-v-cc5de7b2] {
+  background-color: white;
+  left: calc(100% - 21px);
+}
+.ui-switch input:checked ~ .ui-switch__background[data-v-cc5de7b2] {
+  margin-left: 0;
+}
+
+
+.checkbox-ui__input:checked ~ .checkbox-ui__mark .v-remixicon[data-v-32d46196],
+.checkbox-ui__input.indeterminate ~ .checkbox-ui__mark .v-remixicon[data-v-32d46196] {
+  transform: scale(1) !important;
+}
+.checkbox-ui .v-remixicon[data-v-32d46196] {
+  transform: scale(0);
+}
+.checkbox-ui__input:checked ~ .checkbox-ui__mark[data-v-32d46196],
+.checkbox-ui__input.indeterminate ~ .checkbox-ui__mark[data-v-32d46196] {
+  --tw-border-opacity: 1;
+  border-color: rgb(var(--color-accent) / var(--tw-border-opacity, 1));
+  background-color: rgb(var(--color-accent) / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 1;
+}
+.checkbox-ui__mark[data-v-32d46196] {
+  width: 100%;
+  height: 100%;
+  transition-property: background-color, border-color;
+  transition-timing-function: ease;
+  transition-duration: 200ms;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.checkbox-ui__mark .v-remixicon[data-v-32d46196] {
+  transform: scale(0) !important;
+  transition: transform 200ms ease;
+}
+
+
+.expand-enter-active,
+.expand-leave-active {
+  transition: height 0.2s ease-in-out;
+  overflow: hidden;
+}
+.expand-enter,
+.expand-leave-to {
+  height: 0;
+}
+
+*, ::before, ::after {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}/*
+! tailwindcss v3.4.17 | MIT License | https://tailwindcss.com
+*//*
+1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
+2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
+*/
+
+*,
+::before,
+::after {
+  box-sizing: border-box; /* 1 */
+  border-width: 0; /* 2 */
+  border-style: solid; /* 2 */
+  border-color: #e4e4e7; /* 2 */
+}
+
+::before,
+::after {
+  --tw-content: '';
+}
+
+/*
+1. Use a consistent sensible line-height in all browsers.
+2. Prevent adjustments of font size after orientation changes in iOS.
+3. Use a more readable tab size.
+4. Use the user's configured `sans` font-family by default.
+5. Use the user's configured `sans` font-feature-settings by default.
+6. Use the user's configured `sans` font-variation-settings by default.
+7. Disable tap highlights on iOS
+*/
+
+html,
+:host {
+  line-height: 1.5; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+  -moz-tab-size: 4; /* 3 */
+  -o-tab-size: 4;
+     tab-size: 4; /* 3 */
+  font-family: Poppins, sans-serif; /* 4 */
+  font-feature-settings: normal; /* 5 */
+  font-variation-settings: normal; /* 6 */
+  -webkit-tap-highlight-color: transparent; /* 7 */
+}
+
+/*
+1. Remove the margin in all browsers.
+2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+*/
+
+body {
+  margin: 0; /* 1 */
+  line-height: inherit; /* 2 */
+}
+
+/*
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+3. Ensure horizontal rules are visible by default.
+*/
+
+hr {
+  height: 0; /* 1 */
+  color: inherit; /* 2 */
+  border-top-width: 1px; /* 3 */
+}
+
+/*
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr:where([title]) {
+  -webkit-text-decoration: underline dotted;
+          text-decoration: underline dotted;
+}
+
+/*
+Remove the default font size and weight for headings.
+*/
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/*
+Reset links to optimize for opt-in styling instead of opt-out.
+*/
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/*
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/*
+1. Use the user's configured `mono` font-family by default.
+2. Use the user's configured `mono` font-feature-settings by default.
+3. Use the user's configured `mono` font-variation-settings by default.
+4. Correct the odd `em` font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family: Source Code Pro, monospace; /* 1 */
+  font-feature-settings: normal; /* 2 */
+  font-variation-settings: normal; /* 3 */
+  font-size: 1em; /* 4 */
+}
+
+/*
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/*
+Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+3. Remove gaps between table borders by default.
+*/
+
+table {
+  text-indent: 0; /* 1 */
+  border-color: inherit; /* 2 */
+  border-collapse: collapse; /* 3 */
+}
+
+/*
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+3. Remove default padding in all browsers.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-feature-settings: inherit; /* 1 */
+  font-variation-settings: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  font-weight: inherit; /* 1 */
+  line-height: inherit; /* 1 */
+  letter-spacing: inherit; /* 1 */
+  color: inherit; /* 1 */
+  margin: 0; /* 2 */
+  padding: 0; /* 3 */
+}
+
+/*
+Remove the inheritance of text transform in Edge and Firefox.
+*/
+
+button,
+select {
+  text-transform: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Remove default button styles.
+*/
+
+button,
+input:where([type='button']),
+input:where([type='reset']),
+input:where([type='submit']) {
+  -webkit-appearance: button; /* 1 */
+  background-color: transparent; /* 2 */
+  background-image: none; /* 2 */
+}
+
+/*
+Use the modern Firefox focus style for all focusable elements.
+*/
+
+:-moz-focusring {
+  outline: auto;
+}
+
+/*
+Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
+*/
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+/*
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/*
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/*
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/*
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to `inherit` in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/*
+Removes the default spacing and border for appropriate elements.
+*/
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  padding: 0;
+}
+
+ol,
+ul,
+menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/*
+Reset default styling for dialogs.
+*/
+dialog {
+  padding: 0;
+}
+
+/*
+Prevent resizing textareas horizontally by default.
+*/
+
+textarea {
+  resize: vertical;
+}
+
+/*
+1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+2. Set the default placeholder color to the user's configured gray 400 color.
+*/
+
+input::-moz-placeholder, textarea::-moz-placeholder {
+  opacity: 1; /* 1 */
+  color: #a1a1aa; /* 2 */
+}
+
+input::placeholder,
+textarea::placeholder {
+  opacity: 1; /* 1 */
+  color: #a1a1aa; /* 2 */
+}
+
+/*
+Set the default cursor for buttons.
+*/
+
+button,
+[role="button"] {
+  cursor: pointer;
+}
+
+/*
+Make sure disabled buttons don't get the pointer cursor.
+*/
+:disabled {
+  cursor: default;
+}
+
+/*
+1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+   This can trigger a poorly considered lint error in some tools but is included by design.
+*/
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block; /* 1 */
+  vertical-align: middle; /* 2 */
+}
+
+/*
+Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+*/
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Make elements with the HTML hidden attribute stay hidden by default */
+[hidden]:where(:not([hidden="until-found"])) {
+  display: none;
+}
+.\!container {
+  width: 100% !important;
+  margin-right: auto !important;
+  margin-left: auto !important;
+  padding-right: 1rem !important;
+  padding-left: 1rem !important;
+}
+.container {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+@media (min-width: 640px) {
+
+  .\!container {
+    max-width: 640px !important;
+    padding-right: 2rem !important;
+    padding-left: 2rem !important;
+  }
+
+  .container {
+    max-width: 640px;
+    padding-right: 2rem;
+    padding-left: 2rem;
+  }
+}
+@media (min-width: 768px) {
+
+  .\!container {
+    max-width: 768px !important;
+  }
+
+  .container {
+    max-width: 768px;
+  }
+}
+@media (min-width: 1024px) {
+
+  .\!container {
+    max-width: 1024px !important;
+  }
+
+  .container {
+    max-width: 1024px;
+  }
+}
+@media (min-width: 1280px) {
+
+  .\!container {
+    max-width: 1280px !important;
+  }
+
+  .container {
+    max-width: 1280px;
+  }
+}
+@media (min-width: 1536px) {
+
+  .\!container {
+    max-width: 1536px !important;
+  }
+
+  .container {
+    max-width: 1536px;
+  }
+}
+.prose {
+  color: var(--tw-prose-body);
+  max-width: 65ch;
+}
+.prose :where(p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+.prose :where([class~="lead"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-lead);
+  font-size: 1.25em;
+  line-height: 1.6;
+  margin-top: 1.2em;
+  margin-bottom: 1.2em;
+}
+.prose :where(a):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-links);
+  text-decoration: underline;
+  font-weight: 500;
+}
+.prose :where(strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-bold);
+  font-weight: 600;
+}
+.prose :where(a strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+.prose :where(blockquote strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+.prose :where(thead th strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+.prose :where(ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: decimal;
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+  padding-inline-start: 1.625em;
+}
+.prose :where(ol[type="A"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: upper-alpha;
+}
+.prose :where(ol[type="a"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: lower-alpha;
+}
+.prose :where(ol[type="A" s]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: upper-alpha;
+}
+.prose :where(ol[type="a" s]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: lower-alpha;
+}
+.prose :where(ol[type="I"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: upper-roman;
+}
+.prose :where(ol[type="i"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: lower-roman;
+}
+.prose :where(ol[type="I" s]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: upper-roman;
+}
+.prose :where(ol[type="i" s]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: lower-roman;
+}
+.prose :where(ol[type="1"]):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: decimal;
+}
+.prose :where(ul):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  list-style-type: disc;
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+  padding-inline-start: 1.625em;
+}
+.prose :where(ol > li):not(:where([class~="not-prose"],[class~="not-prose"] *))::marker {
+  font-weight: 400;
+  color: var(--tw-prose-counters);
+}
+.prose :where(ul > li):not(:where([class~="not-prose"],[class~="not-prose"] *))::marker {
+  color: var(--tw-prose-bullets);
+}
+.prose :where(dt):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  margin-top: 1.25em;
+}
+.prose :where(hr):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border-color: var(--tw-prose-hr);
+  border-top-width: 1px;
+  margin-top: 3em;
+  margin-bottom: 3em;
+}
+.prose :where(blockquote):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 500;
+  font-style: italic;
+  color: var(--tw-prose-quotes);
+  border-inline-start-width: 0.25rem;
+  border-inline-start-color: var(--tw-prose-quote-borders);
+  quotes: "\201C""\201D""\2018""\2019";
+  margin-top: 1.6em;
+  margin-bottom: 1.6em;
+  padding-inline-start: 1em;
+}
+.prose :where(blockquote p:first-of-type):not(:where([class~="not-prose"],[class~="not-prose"] *))::before {
+  content: open-quote;
+}
+.prose :where(blockquote p:last-of-type):not(:where([class~="not-prose"],[class~="not-prose"] *))::after {
+  content: close-quote;
+}
+.prose :where(h1):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 800;
+  font-size: 2.25em;
+  margin-top: 0;
+  margin-bottom: 0.8888889em;
+  line-height: 1.1111111;
+}
+.prose :where(h1 strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 900;
+  color: inherit;
+}
+.prose :where(h2):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 700;
+  font-size: 1.5em;
+  margin-top: 2em;
+  margin-bottom: 1em;
+  line-height: 1.3333333;
+}
+.prose :where(h2 strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 800;
+  color: inherit;
+}
+.prose :where(h3):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  font-size: 1.25em;
+  margin-top: 1.6em;
+  margin-bottom: 0.6em;
+  line-height: 1.6;
+}
+.prose :where(h3 strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 700;
+  color: inherit;
+}
+.prose :where(h4):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+  line-height: 1.5;
+}
+.prose :where(h4 strong):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 700;
+  color: inherit;
+}
+.prose :where(img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+.prose :where(picture):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  display: block;
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+.prose :where(video):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+.prose :where(kbd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--tw-prose-kbd);
+  box-shadow: 0 0 0 1px rgb(var(--tw-prose-kbd-shadows) / 10%), 0 3px 0 rgb(var(--tw-prose-kbd-shadows) / 10%);
+  font-size: 0.875em;
+  border-radius: 0.3125rem;
+  padding-top: 0.1875em;
+  padding-inline-end: 0.375em;
+  padding-bottom: 0.1875em;
+  padding-inline-start: 0.375em;
+}
+.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-code);
+  font-weight: 600;
+  font-size: 0.875em;
+}
+.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *))::before {
+  content: "`";
+}
+.prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *))::after {
+  content: "`";
+}
+.prose :where(a code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+.prose :where(h1 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+.prose :where(h2 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+  font-size: 0.875em;
+}
+.prose :where(h3 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+  font-size: 0.9em;
+}
+.prose :where(h4 code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+.prose :where(blockquote code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+.prose :where(thead th code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: inherit;
+}
+.prose :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-pre-code);
+  background-color: var(--tw-prose-pre-bg);
+  overflow-x: auto;
+  font-weight: 400;
+  font-size: 0.875em;
+  line-height: 1.7142857;
+  margin-top: 1.7142857em;
+  margin-bottom: 1.7142857em;
+  border-radius: 0.375rem;
+  padding-top: 0.8571429em;
+  padding-inline-end: 1.1428571em;
+  padding-bottom: 0.8571429em;
+  padding-inline-start: 1.1428571em;
+}
+.prose :where(pre code):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  background-color: transparent;
+  border-width: 0;
+  border-radius: 0;
+  padding: 0;
+  font-weight: inherit;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+}
+.prose :where(pre code):not(:where([class~="not-prose"],[class~="not-prose"] *))::before {
+  content: none;
+}
+.prose :where(pre code):not(:where([class~="not-prose"],[class~="not-prose"] *))::after {
+  content: none;
+}
+.prose :where(table):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  width: 100%;
+  table-layout: auto;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  font-size: 0.875em;
+  line-height: 1.7142857;
+}
+.prose :where(thead):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border-bottom-width: 1px;
+  border-bottom-color: var(--tw-prose-th-borders);
+}
+.prose :where(thead th):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-headings);
+  font-weight: 600;
+  vertical-align: bottom;
+  padding-inline-end: 0.5714286em;
+  padding-bottom: 0.5714286em;
+  padding-inline-start: 0.5714286em;
+}
+.prose :where(tbody tr):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border-bottom-width: 1px;
+  border-bottom-color: var(--tw-prose-td-borders);
+}
+.prose :where(tbody tr:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border-bottom-width: 0;
+}
+.prose :where(tbody td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  vertical-align: baseline;
+}
+.prose :where(tfoot):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  border-top-width: 1px;
+  border-top-color: var(--tw-prose-th-borders);
+}
+.prose :where(tfoot td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  vertical-align: top;
+}
+.prose :where(th, td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  text-align: start;
+}
+.prose :where(figure > *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.prose :where(figcaption):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  color: var(--tw-prose-captions);
+  font-size: 0.875em;
+  line-height: 1.4285714;
+  margin-top: 0.8571429em;
+}
+.prose {
+  --tw-prose-body: #374151;
+  --tw-prose-headings: #111827;
+  --tw-prose-lead: #4b5563;
+  --tw-prose-links: #111827;
+  --tw-prose-bold: #111827;
+  --tw-prose-counters: #6b7280;
+  --tw-prose-bullets: #d1d5db;
+  --tw-prose-hr: #e5e7eb;
+  --tw-prose-quotes: #111827;
+  --tw-prose-quote-borders: #e5e7eb;
+  --tw-prose-captions: #6b7280;
+  --tw-prose-kbd: #111827;
+  --tw-prose-kbd-shadows: 17 24 39;
+  --tw-prose-code: #111827;
+  --tw-prose-pre-code: #e5e7eb;
+  --tw-prose-pre-bg: #1f2937;
+  --tw-prose-th-borders: #d1d5db;
+  --tw-prose-td-borders: #e5e7eb;
+  --tw-prose-invert-body: #d1d5db;
+  --tw-prose-invert-headings: #fff;
+  --tw-prose-invert-lead: #9ca3af;
+  --tw-prose-invert-links: #fff;
+  --tw-prose-invert-bold: #fff;
+  --tw-prose-invert-counters: #9ca3af;
+  --tw-prose-invert-bullets: #4b5563;
+  --tw-prose-invert-hr: #374151;
+  --tw-prose-invert-quotes: #f3f4f6;
+  --tw-prose-invert-quote-borders: #374151;
+  --tw-prose-invert-captions: #9ca3af;
+  --tw-prose-invert-kbd: #fff;
+  --tw-prose-invert-kbd-shadows: 255 255 255;
+  --tw-prose-invert-code: #fff;
+  --tw-prose-invert-pre-code: #d1d5db;
+  --tw-prose-invert-pre-bg: rgb(0 0 0 / 50%);
+  --tw-prose-invert-th-borders: #4b5563;
+  --tw-prose-invert-td-borders: #374151;
+  font-size: 1rem;
+  line-height: 1.75;
+}
+.prose :where(picture > img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.prose :where(li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+.prose :where(ol > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0.375em;
+}
+.prose :where(ul > li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0.375em;
+}
+.prose :where(.prose > ul > li p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+.prose :where(.prose > ul > li > p:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.25em;
+}
+.prose :where(.prose > ul > li > p:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 1.25em;
+}
+.prose :where(.prose > ol > li > p:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.25em;
+}
+.prose :where(.prose > ol > li > p:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 1.25em;
+}
+.prose :where(ul ul, ul ol, ol ul, ol ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+.prose :where(dl):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 1.25em;
+  margin-bottom: 1.25em;
+}
+.prose :where(dd):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0.5em;
+  padding-inline-start: 1.625em;
+}
+.prose :where(hr + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+.prose :where(h2 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+.prose :where(h3 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+.prose :where(h4 + *):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+.prose :where(thead th:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0;
+}
+.prose :where(thead th:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-end: 0;
+}
+.prose :where(tbody td, tfoot td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-top: 0.5714286em;
+  padding-inline-end: 0.5714286em;
+  padding-bottom: 0.5714286em;
+  padding-inline-start: 0.5714286em;
+}
+.prose :where(tbody td:first-child, tfoot td:first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-start: 0;
+}
+.prose :where(tbody td:last-child, tfoot td:last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  padding-inline-end: 0;
+}
+.prose :where(figure):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+.prose :where(.prose > :first-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-top: 0;
+}
+.prose :where(.prose > :last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
+  margin-bottom: 0;
+}
+.prose-zinc {
+  --tw-prose-body: #3f3f46;
+  --tw-prose-headings: #18181b;
+  --tw-prose-lead: #52525b;
+  --tw-prose-links: #18181b;
+  --tw-prose-bold: #18181b;
+  --tw-prose-counters: #71717a;
+  --tw-prose-bullets: #d4d4d8;
+  --tw-prose-hr: #e4e4e7;
+  --tw-prose-quotes: #18181b;
+  --tw-prose-quote-borders: #e4e4e7;
+  --tw-prose-captions: #71717a;
+  --tw-prose-kbd: #18181b;
+  --tw-prose-kbd-shadows: 24 24 27;
+  --tw-prose-code: #18181b;
+  --tw-prose-pre-code: #e4e4e7;
+  --tw-prose-pre-bg: #27272a;
+  --tw-prose-th-borders: #d4d4d8;
+  --tw-prose-td-borders: #e4e4e7;
+  --tw-prose-invert-body: #d4d4d8;
+  --tw-prose-invert-headings: #fff;
+  --tw-prose-invert-lead: #a1a1aa;
+  --tw-prose-invert-links: #fff;
+  --tw-prose-invert-bold: #fff;
+  --tw-prose-invert-counters: #a1a1aa;
+  --tw-prose-invert-bullets: #52525b;
+  --tw-prose-invert-hr: #3f3f46;
+  --tw-prose-invert-quotes: #f4f4f5;
+  --tw-prose-invert-quote-borders: #3f3f46;
+  --tw-prose-invert-captions: #a1a1aa;
+  --tw-prose-invert-kbd: #fff;
+  --tw-prose-invert-kbd-shadows: 255 255 255;
+  --tw-prose-invert-code: #fff;
+  --tw-prose-invert-pre-code: #d4d4d8;
+  --tw-prose-invert-pre-bg: rgb(0 0 0 / 50%);
+  --tw-prose-invert-th-borders: #52525b;
+  --tw-prose-invert-td-borders: #3f3f46;
+}
+.pointer-events-none {
+  pointer-events: none;
+}
+.pointer-events-auto {
+  pointer-events: auto;
+}
+.visible {
+  visibility: visible;
+}
+.invisible {
+  visibility: hidden;
+}
+.static {
+  position: static;
+}
+.fixed {
+  position: fixed;
+}
+.absolute {
+  position: absolute;
+}
+.relative {
+  position: relative;
+}
+.sticky {
+  position: sticky;
+}
+.-right-2 {
+  right: -8px;
+}
+.-top-1 {
+  top: -4px;
+}
+.-top-2 {
+  top: -8px;
+}
+.bottom-0 {
+  bottom: 0px;
+}
+.bottom-2 {
+  bottom: 8px;
+}
+.bottom-5 {
+  bottom: 20px;
+}
+.bottom-8 {
+  bottom: 32px;
+}
+.left-0 {
+  left: 0px;
+}
+.left-1\/2 {
+  left: 50%;
+}
+.left-2 {
+  left: 8px;
+}
+.right-0 {
+  right: 0px;
+}
+.right-2 {
+  right: 8px;
+}
+.right-4 {
+  right: 16px;
+}
+.right-8 {
+  right: 32px;
+}
+.top-0 {
+  top: 0px;
+}
+.top-1\/2 {
+  top: 50%;
+}
+.top-2 {
+  top: 8px;
+}
+.top-4 {
+  top: 16px;
+}
+.top-8 {
+  top: 32px;
+}
+.top-full {
+  top: 100%;
+}
+.z-0 {
+  z-index: 0;
+}
+.z-10 {
+  z-index: 10;
+}
+.z-20 {
+  z-index: 20;
+}
+.z-40 {
+  z-index: 40;
+}
+.z-50 {
+  z-index: 50;
+}
+.z-\[1\] {
+  z-index: 1;
+}
+.col-span-1 {
+  grid-column: span 1 / span 1;
+}
+.col-span-2 {
+  grid-column: span 2 / span 2;
+}
+.col-span-3 {
+  grid-column: span 3 / span 3;
+}
+.col-span-4 {
+  grid-column: span 4 / span 4;
+}
+.col-span-5 {
+  grid-column: span 5 / span 5;
+}
+.col-span-6 {
+  grid-column: span 6 / span 6;
+}
+.m-4 {
+  margin: 16px;
+}
+.m-5 {
+  margin: 20px;
+}
+.mx-1 {
+  margin-left: 4px;
+  margin-right: 4px;
+}
+.mx-2 {
+  margin-left: 8px;
+  margin-right: 8px;
+}
+.mx-4 {
+  margin-left: 16px;
+  margin-right: 16px;
+}
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+.my-1 {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+.my-2 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+.my-4 {
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+.my-6 {
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+.my-8 {
+  margin-top: 32px;
+  margin-bottom: 32px;
+}
+.-ml-1 {
+  margin-left: -4px;
+}
+.-ml-2 {
+  margin-left: -8px;
+}
+.-ml-6 {
+  margin-left: -24px;
+}
+.-mr-1 {
+  margin-right: -4px;
+}
+.-mr-2 {
+  margin-right: -8px;
+}
+.-mt-1 {
+  margin-top: -4px;
+}
+.-mt-2 {
+  margin-top: -8px;
+}
+.mb-1 {
+  margin-bottom: 4px;
+}
+.mb-10 {
+  margin-bottom: 40px;
+}
+.mb-12 {
+  margin-bottom: 48px;
+}
+.mb-2 {
+  margin-bottom: 8px;
+}
+.mb-4 {
+  margin-bottom: 16px;
+}
+.mb-6 {
+  margin-bottom: 24px;
+}
+.mb-8 {
+  margin-bottom: 32px;
+}
+.ml-1 {
+  margin-left: 4px;
+}
+.ml-12 {
+  margin-left: 48px;
+}
+.ml-2 {
+  margin-left: 8px;
+}
+.ml-3 {
+  margin-left: 12px;
+}
+.ml-4 {
+  margin-left: 16px;
+}
+.ml-6 {
+  margin-left: 24px;
+}
+.mr-0\.5 {
+  margin-right: 2px;
+}
+.mr-1 {
+  margin-right: 4px;
+}
+.mr-12 {
+  margin-right: 48px;
+}
+.mr-2 {
+  margin-right: 8px;
+}
+.mr-3 {
+  margin-right: 12px;
+}
+.mr-4 {
+  margin-right: 16px;
+}
+.mr-6 {
+  margin-right: 24px;
+}
+.mr-8 {
+  margin-right: 32px;
+}
+.mt-1 {
+  margin-top: 4px;
+}
+.mt-10 {
+  margin-top: 40px;
+}
+.mt-12 {
+  margin-top: 48px;
+}
+.mt-2 {
+  margin-top: 8px;
+}
+.mt-3 {
+  margin-top: 12px;
+}
+.mt-4 {
+  margin-top: 16px;
+}
+.mt-5 {
+  margin-top: 20px;
+}
+.mt-6 {
+  margin-top: 24px;
+}
+.mt-8 {
+  margin-top: 32px;
+}
+.\!block {
+  display: block !important;
+}
+.block {
+  display: block;
+}
+.inline-block {
+  display: inline-block;
+}
+.inline {
+  display: inline;
+}
+.\!flex {
+  display: flex !important;
+}
+.flex {
+  display: flex;
+}
+.inline-flex {
+  display: inline-flex;
+}
+.\!table {
+  display: table !important;
+}
+.table {
+  display: table;
+}
+.grid {
+  display: grid;
+}
+.hidden {
+  display: none;
+}
+.\!h-8 {
+  height: 32px !important;
+}
+.h-10 {
+  height: 40px;
+}
+.h-12 {
+  height: 48px;
+}
+.h-28 {
+  height: 112px;
+}
+.h-3 {
+  height: 12px;
+}
+.h-32 {
+  height: 128px;
+}
+.h-4 {
+  height: 16px;
+}
+.h-40 {
+  height: 160px;
+}
+.h-48 {
+  height: 192px;
+}
+.h-5 {
+  height: 20px;
+}
+.h-56 {
+  height: 224px;
+}
+.h-6 {
+  height: 24px;
+}
+.h-7 {
+  height: 28px;
+}
+.h-72 {
+  height: 288px;
+}
+.h-8 {
+  height: 32px;
+}
+.h-\[105px\] {
+  height: 105px;
+}
+.h-\[1px\] {
+  height: 1px;
+}
+.h-\[22px\] {
+  height: 22px;
+}
+.h-full {
+  height: 100%;
+}
+.h-screen {
+  height: 100vh;
+}
+.max-h-56 {
+  max-height: 224px;
+}
+.max-h-60 {
+  max-height: 240px;
+}
+.max-h-80 {
+  max-height: 320px;
+}
+.max-h-96 {
+  max-height: 384px;
+}
+.w-10 {
+  width: 40px;
+}
+.w-11\/12 {
+  width: 91.666667%;
+}
+.w-12 {
+  width: 48px;
+}
+.w-14 {
+  width: 56px;
+}
+.w-16 {
+  width: 64px;
+}
+.w-2 {
+  width: 8px;
+}
+.w-2\/12 {
+  width: 16.666667%;
+}
+.w-20 {
+  width: 80px;
+}
+.w-24 {
+  width: 96px;
+}
+.w-3 {
+  width: 12px;
+}
+.w-3\/12 {
+  width: 25%;
+}
+.w-32 {
+  width: 128px;
+}
+.w-36 {
+  width: 144px;
+}
+.w-4 {
+  width: 16px;
+}
+.w-4\/12 {
+  width: 33.333333%;
+}
+.w-40 {
+  width: 160px;
+}
+.w-44 {
+  width: 176px;
+}
+.w-48 {
+  width: 192px;
+}
+.w-5 {
+  width: 20px;
+}
+.w-5\/12 {
+  width: 41.666667%;
+}
+.w-52 {
+  width: 208px;
+}
+.w-56 {
+  width: 224px;
+}
+.w-6\/12 {
+  width: 50%;
+}
+.w-60 {
+  width: 240px;
+}
+.w-64 {
+  width: 256px;
+}
+.w-72 {
+  width: 288px;
+}
+.w-8 {
+  width: 32px;
+}
+.w-8\/12 {
+  width: 66.666667%;
+}
+.w-80 {
+  width: 320px;
+}
+.w-96 {
+  width: 384px;
+}
+.w-full {
+  width: 100%;
+}
+.w-px {
+  width: 1px;
+}
+.min-w-\[52px\] {
+  min-width: 52px;
+}
+.min-w-\[90px\] {
+  min-width: 90px;
+}
+.max-w-2xl {
+  max-width: 672px;
+}
+.max-w-3xl {
+  max-width: 768px;
+}
+.max-w-4xl {
+  max-width: 896px;
+}
+.max-w-5xl {
+  max-width: 1024px;
+}
+.max-w-\[170px\] {
+  max-width: 170px;
+}
+.max-w-lg {
+  max-width: 512px;
+}
+.max-w-md {
+  max-width: 448px;
+}
+.max-w-none {
+  max-width: none;
+}
+.max-w-sm {
+  max-width: 384px;
+}
+.max-w-xl {
+  max-width: 576px;
+}
+.flex-1 {
+  flex: 1 1 0%;
+}
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+.shrink-0 {
+  flex-shrink: 0;
+}
+.grow {
+  flex-grow: 1;
+}
+.-translate-x-1\/2 {
+  --tw-translate-x: -50%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+.-translate-y-1 {
+  --tw-translate-y: -4px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+.-translate-y-1\/2 {
+  --tw-translate-y: -50%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+.rotate-180 {
+  --tw-rotate: 180deg;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+.scale-0 {
+  --tw-scale-x: 0;
+  --tw-scale-y: 0;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+.transform {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+@keyframes ping {
+
+  75%, 100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+.animate-ping {
+  animation: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+@keyframes pulse {
+
+  50% {
+    opacity: .5;
+  }
+}
+.animate-pulse {
+  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+@keyframes spin {
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+.animate-spin {
+  animation: spin 1s linear infinite;
+}
+.cursor-default {
+  cursor: default;
+}
+.cursor-grab {
+  cursor: grab;
+}
+.cursor-grabbing {
+  cursor: grabbing;
+}
+.cursor-move {
+  cursor: move;
+}
+.cursor-pointer {
+  cursor: pointer;
+}
+.select-none {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+.resize-none {
+  resize: none;
+}
+.resize {
+  resize: both;
+}
+.list-inside {
+  list-style-position: inside;
+}
+.list-decimal {
+  list-style-type: decimal;
+}
+.list-disc {
+  list-style-type: disc;
+}
+.appearance-none {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+}
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+.grid-cols-12 {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.grid-cols-5 {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+.grid-cols-6 {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+.grid-cols-7 {
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+.flex-col {
+  flex-direction: column;
+}
+.flex-col-reverse {
+  flex-direction: column-reverse;
+}
+.flex-wrap {
+  flex-wrap: wrap;
+}
+.items-start {
+  align-items: flex-start;
+}
+.items-end {
+  align-items: flex-end;
+}
+.items-center {
+  align-items: center;
+}
+.\!items-stretch {
+  align-items: stretch !important;
+}
+.justify-end {
+  justify-content: flex-end;
+}
+.justify-center {
+  justify-content: center;
+}
+.justify-between {
+  justify-content: space-between;
+}
+.justify-items-center {
+  justify-items: center;
+}
+.gap-1 {
+  gap: 4px;
+}
+.gap-2 {
+  gap: 8px;
+}
+.gap-3 {
+  gap: 12px;
+}
+.gap-4 {
+  gap: 16px;
+}
+.gap-x-2 {
+  -moz-column-gap: 8px;
+       column-gap: 8px;
+}
+.gap-x-4 {
+  -moz-column-gap: 16px;
+       column-gap: 16px;
+}
+.gap-y-2 {
+  row-gap: 8px;
+}
+.space-x-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(4px * var(--tw-space-x-reverse));
+  margin-left: calc(4px * calc(1 - var(--tw-space-x-reverse)));
+}
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(8px * var(--tw-space-x-reverse));
+  margin-left: calc(8px * calc(1 - var(--tw-space-x-reverse)));
+}
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(12px * var(--tw-space-x-reverse));
+  margin-left: calc(12px * calc(1 - var(--tw-space-x-reverse)));
+}
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(16px * var(--tw-space-x-reverse));
+  margin-left: calc(16px * calc(1 - var(--tw-space-x-reverse)));
+}
+.space-x-6 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(24px * var(--tw-space-x-reverse));
+  margin-left: calc(24px * calc(1 - var(--tw-space-x-reverse)));
+}
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(4px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(4px * var(--tw-space-y-reverse));
+}
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(8px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(8px * var(--tw-space-y-reverse));
+}
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(16px * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(16px * var(--tw-space-y-reverse));
+}
+.divide-y > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
+}
+.overflow-auto {
+  overflow: auto;
+}
+.overflow-hidden {
+  overflow: hidden;
+}
+.overflow-x-auto {
+  overflow-x: auto;
+}
+.overflow-y-auto {
+  overflow-y: auto;
+}
+.overflow-y-hidden {
+  overflow-y: hidden;
+}
+.whitespace-nowrap {
+  white-space: nowrap;
+}
+.whitespace-pre-wrap {
+  white-space: pre-wrap;
+}
+.rounded {
+  border-radius: 4px;
+}
+.rounded-full {
+  border-radius: 9999px;
+}
+.rounded-lg {
+  border-radius: 8px;
+}
+.rounded-md {
+  border-radius: 6px;
+}
+.rounded-sm {
+  border-radius: 2px;
+}
+.rounded-b-2xl {
+  border-bottom-right-radius: 16px;
+  border-bottom-left-radius: 16px;
+}
+.rounded-l-lg {
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+.rounded-l-none {
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+.rounded-r-lg {
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+.rounded-r-none {
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+.rounded-t-none {
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+}
+.rounded-bl-\[22px\] {
+  border-bottom-left-radius: 22px;
+}
+.rounded-bl-lg {
+  border-bottom-left-radius: 8px;
+}
+.rounded-br-lg {
+  border-bottom-right-radius: 8px;
+}
+.rounded-tr-lg {
+  border-top-right-radius: 8px;
+}
+.border {
+  border-width: 1px;
+}
+.border-2 {
+  border-width: 2px;
+}
+.border-x {
+  border-left-width: 1px;
+  border-right-width: 1px;
+}
+.border-b {
+  border-bottom-width: 1px;
+}
+.border-b-0 {
+  border-bottom-width: 0px;
+}
+.border-b-2 {
+  border-bottom-width: 2px;
+}
+.border-l {
+  border-left-width: 1px;
+}
+.border-r {
+  border-right-width: 1px;
+}
+.border-r-0 {
+  border-right-width: 0px;
+}
+.border-t {
+  border-top-width: 1px;
+}
+.border-dashed {
+  border-style: dashed;
+}
+.border-none {
+  border-style: none;
+}
+.border-accent {
+  --tw-border-opacity: 1;
+  border-color: rgb(var(--color-accent) / var(--tw-border-opacity, 1));
+}
+.border-blue-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(191 219 254 / var(--tw-border-opacity, 1));
+}
+.border-blue-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
+}
+.border-cyan-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(165 243 252 / var(--tw-border-opacity, 1));
+}
+.border-gray-100 {
+  --tw-border-opacity: 1;
+  border-color: rgb(244 244 245 / var(--tw-border-opacity, 1));
+}
+.border-gray-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(228 228 231 / var(--tw-border-opacity, 1));
+}
+.border-gray-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(212 212 216 / var(--tw-border-opacity, 1));
+}
+.border-green-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(187 247 208 / var(--tw-border-opacity, 1));
+}
+.border-lime-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(217 249 157 / var(--tw-border-opacity, 1));
+}
+.border-orange-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 215 170 / var(--tw-border-opacity, 1));
+}
+.border-red-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 202 202 / var(--tw-border-opacity, 1));
+}
+.border-red-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(239 68 68 / var(--tw-border-opacity, 1));
+}
+.border-transparent {
+  border-color: transparent;
+}
+.border-yellow-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 240 138 / var(--tw-border-opacity, 1));
+}
+.bg-\[\#79FFEB\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(121 255 235 / var(--tw-bg-opacity, 1));
+}
+.bg-\[\#e4e4e7\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+}
+.bg-\[\#f2f2f2\] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(242 242 242 / var(--tw-bg-opacity, 1));
+}
+.bg-accent {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-accent) / var(--tw-bg-opacity, 1));
+}
+.bg-amber-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(253 230 138 / var(--tw-bg-opacity, 1));
+}
+.bg-black {
+  --tw-bg-opacity: 1;
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity, 1));
+}
+.bg-blue-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(191 219 254 / var(--tw-bg-opacity, 1));
+}
+.bg-blue-300 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(147 197 253 / var(--tw-bg-opacity, 1));
+}
+.bg-blue-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(59 130 246 / var(--tw-bg-opacity, 1));
+}
+.bg-blue-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+}
+.bg-cyan-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(165 243 252 / var(--tw-bg-opacity, 1));
+}
+.bg-gray-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(244 244 245 / var(--tw-bg-opacity, 1));
+}
+.bg-gray-300 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(212 212 216 / var(--tw-bg-opacity, 1));
+}
+.bg-gray-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(250 250 250 / var(--tw-bg-opacity, 1));
+}
+.bg-gray-700 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(63 63 70 / var(--tw-bg-opacity, 1));
+}
+.bg-gray-900 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(24 24 27 / var(--tw-bg-opacity, 1));
+}
+.bg-green-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(187 247 208 / var(--tw-bg-opacity, 1));
+}
+.bg-green-300 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(134 239 172 / var(--tw-bg-opacity, 1));
+}
+.bg-indigo-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(199 210 254 / var(--tw-bg-opacity, 1));
+}
+.bg-indigo-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(99 102 241 / var(--tw-bg-opacity, 1));
+}
+.bg-lime-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(217 249 157 / var(--tw-bg-opacity, 1));
+}
+.bg-orange-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 215 170 / var(--tw-bg-opacity, 1));
+}
+.bg-primary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-primary) / var(--tw-bg-opacity, 1));
+}
+.bg-red-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity, 1));
+}
+.bg-red-300 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(252 165 165 / var(--tw-bg-opacity, 1));
+}
+.bg-red-400 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(248 113 113 / var(--tw-bg-opacity, 1));
+}
+.bg-sky-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(186 230 253 / var(--tw-bg-opacity, 1));
+}
+.bg-transparent {
+  background-color: transparent;
+}
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+}
+.bg-yellow-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 240 138 / var(--tw-bg-opacity, 1));
+}
+.bg-opacity-10 {
+  --tw-bg-opacity: 0.1;
+}
+.bg-opacity-20 {
+  --tw-bg-opacity: 0.2;
+}
+.bg-opacity-30 {
+  --tw-bg-opacity: 0.3;
+}
+.bg-opacity-5 {
+  --tw-bg-opacity: 0.05;
+}
+.bg-opacity-50 {
+  --tw-bg-opacity: 0.5;
+}
+.bg-opacity-75 {
+  --tw-bg-opacity: 0.75;
+}
+.bg-scroll {
+  background-attachment: scroll;
+}
+.bg-center {
+  background-position: center;
+}
+.bg-no-repeat {
+  background-repeat: no-repeat;
+}
+.fill-blue-200 {
+  fill: #bfdbfe;
+}
+.fill-cyan-200 {
+  fill: #a5f3fc;
+}
+.fill-green-200 {
+  fill: #bbf7d0;
+}
+.fill-lime-200 {
+  fill: #d9f99d;
+}
+.fill-orange-200 {
+  fill: #fed7aa;
+}
+.fill-red-200 {
+  fill: #fecaca;
+}
+.fill-yellow-200 {
+  fill: #fef08a;
+}
+.\!p-0 {
+  padding: 0px !important;
+}
+.p-0 {
+  padding: 0px;
+}
+.p-0\.5 {
+  padding: 2px;
+}
+.p-1 {
+  padding: 4px;
+}
+.p-2 {
+  padding: 8px;
+}
+.p-3 {
+  padding: 12px;
+}
+.p-4 {
+  padding: 16px;
+}
+.p-5 {
+  padding: 20px;
+}
+.p-6 {
+  padding: 24px;
+}
+.\!px-3 {
+  padding-left: 12px !important;
+  padding-right: 12px !important;
+}
+.\!py-2 {
+  padding-top: 8px !important;
+  padding-bottom: 8px !important;
+}
+.px-1 {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+.px-2 {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.px-3 {
+  padding-left: 12px;
+  padding-right: 12px;
+}
+.px-4 {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+.px-5 {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+.py-1 {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+.py-12 {
+  padding-top: 48px;
+  padding-bottom: 48px;
+}
+.py-16 {
+  padding-top: 64px;
+  padding-bottom: 64px;
+}
+.py-2 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+.py-3 {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+.py-4 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+.py-6 {
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+.py-8 {
+  padding-top: 32px;
+  padding-bottom: 32px;
+}
+.py-px {
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+.pb-1 {
+  padding-bottom: 4px;
+}
+.pb-2 {
+  padding-bottom: 8px;
+}
+.pb-4 {
+  padding-bottom: 16px;
+}
+.pb-5 {
+  padding-bottom: 20px;
+}
+.pb-8 {
+  padding-bottom: 32px;
+}
+.pl-1 {
+  padding-left: 4px;
+}
+.pl-10 {
+  padding-left: 40px;
+}
+.pl-14 {
+  padding-left: 56px;
+}
+.pl-16 {
+  padding-left: 64px;
+}
+.pl-2 {
+  padding-left: 8px;
+}
+.pl-4 {
+  padding-left: 16px;
+}
+.pl-6 {
+  padding-left: 24px;
+}
+.pl-8 {
+  padding-left: 32px;
+}
+.pl-\[28px\] {
+  padding-left: 28px;
+}
+.pr-10 {
+  padding-right: 40px;
+}
+.pr-4 {
+  padding-right: 16px;
+}
+.pt-1 {
+  padding-top: 4px;
+}
+.pt-2 {
+  padding-top: 8px;
+}
+.pt-24 {
+  padding-top: 96px;
+}
+.pt-4 {
+  padding-top: 16px;
+}
+.pt-8 {
+  padding-top: 32px;
+}
+.text-left {
+  text-align: left;
+}
+.text-center {
+  text-align: center;
+}
+.text-right {
+  text-align: right;
+}
+.align-baseline {
+  vertical-align: baseline;
+}
+.align-middle {
+  vertical-align: middle;
+}
+.align-bottom {
+  vertical-align: bottom;
+}
+.align-text-top {
+  vertical-align: text-top;
+}
+.align-text-bottom {
+  vertical-align: text-bottom;
+}
+.align-sub {
+  vertical-align: sub;
+}
+.font-mono {
+  font-family: Source Code Pro, monospace;
+}
+.text-2xl {
+  font-size: 24px;
+  line-height: 32px;
+}
+.text-3xl {
+  font-size: 30px;
+  line-height: 36px;
+}
+.text-\[14px\] {
+  font-size: 14px;
+}
+.text-\[16px\] {
+  font-size: 16px;
+}
+.text-base {
+  font-size: 16px;
+  line-height: 24px;
+}
+.text-lg {
+  font-size: 18px;
+  line-height: 28px;
+}
+.text-sm {
+  font-size: 14px;
+  line-height: 20px;
+}
+.text-xl {
+  font-size: 20px;
+  line-height: 28px;
+}
+.text-xs {
+  font-size: 12px;
+  line-height: 16px;
+}
+.font-semibold {
+  font-weight: 600;
+}
+.uppercase {
+  text-transform: uppercase;
+}
+.lowercase {
+  text-transform: lowercase;
+}
+.\!capitalize {
+  text-transform: capitalize !important;
+}
+.capitalize {
+  text-transform: capitalize;
+}
+.italic {
+  font-style: italic;
+}
+.tabular-nums {
+  --tw-numeric-spacing: tabular-nums;
+  font-variant-numeric: var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction);
+}
+.leading-\[24px\] {
+  line-height: 24px;
+}
+.leading-none {
+  line-height: 1;
+}
+.leading-normal {
+  line-height: 1.5;
+}
+.leading-tight {
+  line-height: 1.25;
+}
+.text-accent {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-accent) / var(--tw-text-opacity, 1));
+}
+.text-black {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity, 1));
+}
+.text-blue-300 {
+  --tw-text-opacity: 1;
+  color: rgb(147 197 253 / var(--tw-text-opacity, 1));
+}
+.text-blue-400 {
+  --tw-text-opacity: 1;
+  color: rgb(96 165 250 / var(--tw-text-opacity, 1));
+}
+.text-gray-100 {
+  --tw-text-opacity: 1;
+  color: rgb(244 244 245 / var(--tw-text-opacity, 1));
+}
+.text-gray-200 {
+  --tw-text-opacity: 1;
+  color: rgb(228 228 231 / var(--tw-text-opacity, 1));
+}
+.text-gray-300 {
+  --tw-text-opacity: 1;
+  color: rgb(212 212 216 / var(--tw-text-opacity, 1));
+}
+.text-gray-400 {
+  --tw-text-opacity: 1;
+  color: rgb(161 161 170 / var(--tw-text-opacity, 1));
+}
+.text-gray-500 {
+  --tw-text-opacity: 1;
+  color: rgb(113 113 122 / var(--tw-text-opacity, 1));
+}
+.text-gray-600 {
+  --tw-text-opacity: 1;
+  color: rgb(82 82 91 / var(--tw-text-opacity, 1));
+}
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgb(63 63 70 / var(--tw-text-opacity, 1));
+}
+.text-gray-800 {
+  --tw-text-opacity: 1;
+  color: rgb(39 39 42 / var(--tw-text-opacity, 1));
+}
+.text-green-400 {
+  --tw-text-opacity: 1;
+  color: rgb(74 222 128 / var(--tw-text-opacity, 1));
+}
+.text-green-500 {
+  --tw-text-opacity: 1;
+  color: rgb(34 197 94 / var(--tw-text-opacity, 1));
+}
+.text-green-600 {
+  --tw-text-opacity: 1;
+  color: rgb(22 163 74 / var(--tw-text-opacity, 1));
+}
+.text-primary {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-primary) / var(--tw-text-opacity, 1));
+}
+.text-red-400 {
+  --tw-text-opacity: 1;
+  color: rgb(248 113 113 / var(--tw-text-opacity, 1));
+}
+.text-red-500 {
+  --tw-text-opacity: 1;
+  color: rgb(239 68 68 / var(--tw-text-opacity, 1));
+}
+.text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+.text-yellow-400 {
+  --tw-text-opacity: 1;
+  color: rgb(250 204 21 / var(--tw-text-opacity, 1));
+}
+.text-yellow-500 {
+  --tw-text-opacity: 1;
+  color: rgb(234 179 8 / var(--tw-text-opacity, 1));
+}
+.underline {
+  text-decoration-line: underline;
+}
+.opacity-0 {
+  opacity: 0;
+}
+.opacity-25 {
+  opacity: 0.25;
+}
+.opacity-50 {
+  opacity: 0.5;
+}
+.opacity-70 {
+  opacity: 0.7;
+}
+.opacity-75 {
+  opacity: 0.75;
+}
+.shadow {
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+.shadow-2xl {
+  --tw-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+  --tw-shadow-colored: 0 25px 50px -12px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+.shadow-lg {
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+.shadow-md {
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+.outline {
+  outline-style: solid;
+}
+.ring {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+.ring-2 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+.ring-accent {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(var(--color-accent) / var(--tw-ring-opacity, 1));
+}
+.ring-red-400 {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(248 113 113 / var(--tw-ring-opacity, 1));
+}
+.blur {
+  --tw-blur: blur(8px);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+.invert {
+  --tw-invert: invert(100%);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+.filter {
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+.backdrop-blur {
+  --tw-backdrop-blur: blur(8px);
+  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+.backdrop-filter {
+  -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+.transition {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+.duration-200 {
+  transition-duration: 200ms;
+}
+.ease-out {
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}
+.hoverable:hover {
+  background-color: rgb(39 39 42 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.05;
+}
+.hoverable:hover:is(.dark *) {
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.05;
+}
+.bg-input {
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.05;
+}
+.bg-input:hover {
+  --tw-bg-opacity: 0.1;
+}
+.bg-input:is(.dark *) {
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.05;
+}
+.bg-input:hover:is(.dark *) {
+  --tw-bg-opacity: 0.1;
+}
+.bg-box-transparent {
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.05;
+}
+.bg-box-transparent:is(.dark *) {
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.05;
+}
+.bg-box-transparent-2 {
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.1;
+}
+.bg-box-transparent-2:is(.dark *) {
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.1;
+}
+
+:host, :root {
+  --color-primary: 59 130 246;
+  --color-secondary: 96 165 250;
+  --color-accent: 24 24 27;
+}
+.dark {
+  --color-primary: 96 165 250;
+  --color-secondary: 59 130 246;
+  --color-accent: 244 244 245;
+}
+
+*:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(63 63 70 / var(--tw-border-opacity, 1));
+}
+
+html.dark {
+  --tw-bg-opacity: 1;
+  background-color: rgb(24 24 27 / var(--tw-bg-opacity, 1));
+}
+
+body, :host {
+  font-family: 'Inter var', sans-serif !important;
+  font-size: 16px !important;
+  font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+  --tw-bg-opacity: 1;
+  background-color: rgb(250 250 250 / var(--tw-bg-opacity, 1));
+  line-height: 1.5;
+}
+
+body:is(.dark *), :host:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(24 24 27 / var(--tw-bg-opacity, 1));
+}
+table th,
+table td {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+input:focus,
+button:focus,
+textarea:focus,
+select:focus,
+[role='button']:focus {
+  outline: none;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(var(--color-accent) / var(--tw-ring-opacity, 1));
+}
+input:focus:is(.dark *),
+button:focus:is(.dark *),
+textarea:focus:is(.dark *),
+select:focus:is(.dark *),
+[role='button']:focus:is(.dark *) {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(228 228 231 / var(--tw-ring-opacity, 1));
+}
+
+.text-overflow {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.line-clamp {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+
+.custom-table thead {
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.05;
+}
+
+
+.custom-table thead:is(.dark *) {
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.05;
+}
+.custom-table thead th {
+  font-weight: 600;
+}
+.custom-table thead th:first-child {
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+.custom-table thead th:last-child {
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+.custom-table tbody > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
+}
+
+
+
+pre {
+  font-size: 15px;
+}
+
+.scroll::-webkit-scrollbar, .scroll .cm-scroller::-webkit-scrollbar {
+    width: 7px;
+    height: 9px;
+  }
+
+.scroll::-webkit-scrollbar-thumb, .scroll .cm-scroller::-webkit-scrollbar-thumb {
+  --tw-bg-opacity: 1;
+  background-color: rgb(212 212 216 / var(--tw-bg-opacity, 1));
+}
+
+.scroll:is(.dark *)::-webkit-scrollbar-thumb, .scroll .cm-scroller:is(.dark *)::-webkit-scrollbar-thumb {
+  --tw-bg-opacity: 1;
+  background-color: rgb(63 63 70 / var(--tw-bg-opacity, 1));
+}
+
+.scroll::-webkit-scrollbar-thumb, .scroll .cm-scroller::-webkit-scrollbar-thumb {
+    border-radius: 8px;
+  }
+
+.scroll::-webkit-scrollbar-track, .scroll .cm-scroller::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+.scroll.scroll-xs::-webkit-scrollbar, .scroll .cm-scroller.scroll-xs::-webkit-scrollbar {
+    width: 5px;
+    height: 5px;
+  }
+
+
+.tippy-box[data-theme~='tooltip-theme'] {
+  border-radius: 6px;
+  --tw-bg-opacity: 1;
+  background-color: rgb(24 24 27 / var(--tw-bg-opacity, 1));
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  font-size: 14px;
+  line-height: 20px;
+  --tw-text-opacity: 1;
+  color: rgb(228 228 231 / var(--tw-text-opacity, 1));
+}
+
+
+.tippy-box[data-theme~='tooltip-theme']:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity, 1));
+}
+.Vue-Toastification__toast {
+  font-family: inherit !important;
+}
+.ProseMirror > * + * {
+  margin-top: 0.75em;
+}
+.ProseMirror img {
+  max-width: 100%;
+  height: auto;
+}
+.ProseMirror img.ProseMirror-selectednode {
+  outline: 3px solid #68CEF8;
+}
+
+.input-label {
+  margin-left: 4px;
+  font-size: 14px;
+  line-height: 20px;
+  --tw-text-opacity: 1;
+  color: rgb(82 82 91 / var(--tw-text-opacity, 1));
+}
+
+.input-label:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(228 228 231 / var(--tw-text-opacity, 1));
+}
+
+.dark\:prose-invert:is(.dark *) {
+  --tw-prose-body: var(--tw-prose-invert-body);
+  --tw-prose-headings: var(--tw-prose-invert-headings);
+  --tw-prose-lead: var(--tw-prose-invert-lead);
+  --tw-prose-links: var(--tw-prose-invert-links);
+  --tw-prose-bold: var(--tw-prose-invert-bold);
+  --tw-prose-counters: var(--tw-prose-invert-counters);
+  --tw-prose-bullets: var(--tw-prose-invert-bullets);
+  --tw-prose-hr: var(--tw-prose-invert-hr);
+  --tw-prose-quotes: var(--tw-prose-invert-quotes);
+  --tw-prose-quote-borders: var(--tw-prose-invert-quote-borders);
+  --tw-prose-captions: var(--tw-prose-invert-captions);
+  --tw-prose-kbd: var(--tw-prose-invert-kbd);
+  --tw-prose-kbd-shadows: var(--tw-prose-invert-kbd-shadows);
+  --tw-prose-code: var(--tw-prose-invert-code);
+  --tw-prose-pre-code: var(--tw-prose-invert-pre-code);
+  --tw-prose-pre-bg: var(--tw-prose-invert-pre-bg);
+  --tw-prose-th-borders: var(--tw-prose-invert-th-borders);
+  --tw-prose-td-borders: var(--tw-prose-invert-td-borders);
+}
+
+.placeholder\:text-black::-moz-placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity, 1));
+}
+
+.placeholder\:text-black::placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity, 1));
+}
+
+.focus-within\:ring-2:focus-within {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus-within\:ring-accent:focus-within {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(var(--color-accent) / var(--tw-ring-opacity, 1));
+}
+
+.focus-within\:bg-box-transparent-2:focus-within {
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.1;
+}
+
+.focus-within\:bg-box-transparent-2:focus-within:is(.dark *) {
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+  --tw-bg-opacity: 0.1;
+}
+
+.hover\:-translate-y-1:hover {
+  --tw-translate-y: -4px;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.hover\:bg-gray-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(244 244 245 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-gray-700:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(63 63 70 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-red-400:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(248 113 113 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-secondary:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-secondary) / var(--tw-bg-opacity, 1));
+}
+
+.hover\:text-black:hover {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity, 1));
+}
+
+.hover\:shadow-xl:hover {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\:ring-2:hover {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.hover\:ring-accent:hover {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(var(--color-accent) / var(--tw-ring-opacity, 1));
+}
+
+.hover\:ring-gray-900:hover {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(24 24 27 / var(--tw-ring-opacity, 1));
+}
+
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.focus\:ring-0:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-2:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.focus\:ring-red-400:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(248 113 113 / var(--tw-ring-opacity, 1));
+}
+
+.group:hover .group-hover\:visible {
+  visibility: visible;
+}
+
+.group:hover .group-hover\:invisible {
+  visibility: hidden;
+}
+
+.group:hover .group-hover\:scale-100 {
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.dark\:divide-gray-700:is(.dark *) > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+  border-color: rgb(63 63 70 / var(--tw-divide-opacity, 1));
+}
+
+.dark\:divide-gray-800:is(.dark *) > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+  border-color: rgb(39 39 42 / var(--tw-divide-opacity, 1));
+}
+
+.dark\:border-accent:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(var(--color-accent) / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-blue-300:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(147 197 253 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-blue-400:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(96 165 250 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-cyan-300:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(103 232 249 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-gray-100:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(244 244 245 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-gray-700:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(63 63 70 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-gray-800:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(39 39 42 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-green-300:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(134 239 172 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-lime-300:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(190 242 100 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-orange-300:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(253 186 116 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-red-300:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(252 165 165 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-transparent:is(.dark *) {
+  border-color: transparent;
+}
+
+.dark\:border-yellow-300:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(253 224 71 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-opacity-40:is(.dark *) {
+  --tw-border-opacity: 0.4;
+}
+
+.dark\:border-opacity-50:is(.dark *) {
+  --tw-border-opacity: 0.5;
+}
+
+.dark\:bg-\[\#2DD4BF\]:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(45 212 191 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-amber-300:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(252 211 77 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-blue-300:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(147 197 253 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-cyan-300:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(103 232 249 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-gray-100:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(244 244 245 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-gray-200:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-gray-600:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(82 82 91 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-gray-700:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(63 63 70 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-gray-800:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(39 39 42 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-gray-900:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(24 24 27 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-green-200:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(187 247 208 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-green-300:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(134 239 172 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-indigo-300:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(165 180 252 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-indigo-400:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(129 140 248 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-lime-300:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(190 242 100 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-orange-300:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(253 186 116 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-red-200:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-red-300:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(252 165 165 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-red-400:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(248 113 113 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-red-500:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 68 68 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-secondary:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-secondary) / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-sky-300:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(125 211 252 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-yellow-300:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(253 224 71 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:bg-opacity-10:is(.dark *) {
+  --tw-bg-opacity: 0.1;
+}
+
+.dark\:bg-opacity-60:is(.dark *) {
+  --tw-bg-opacity: 0.6;
+}
+
+.dark\:bg-none:is(.dark *) {
+  background-image: none;
+}
+
+.dark\:fill-blue-300:is(.dark *) {
+  fill: #93c5fd;
+}
+
+.dark\:fill-cyan-300:is(.dark *) {
+  fill: #67e8f9;
+}
+
+.dark\:fill-green-300:is(.dark *) {
+  fill: #86efac;
+}
+
+.dark\:fill-lime-300:is(.dark *) {
+  fill: #bef264;
+}
+
+.dark\:fill-orange-300:is(.dark *) {
+  fill: #fdba74;
+}
+
+.dark\:fill-red-300:is(.dark *) {
+  fill: #fca5a5;
+}
+
+.dark\:fill-yellow-300:is(.dark *) {
+  fill: #fde047;
+}
+
+.dark\:text-black:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-gray-100:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(244 244 245 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-gray-200:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(228 228 231 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-gray-300:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(212 212 216 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-gray-400:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(161 161 170 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-gray-600:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(82 82 91 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-gray-900:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(24 24 27 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-green-400:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(74 222 128 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-red-300:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(252 165 165 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-red-400:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(248 113 113 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-red-500:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(239 68 68 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-red-600:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-secondary:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(var(--color-secondary) / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-yellow-300:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(253 224 71 / var(--tw-text-opacity, 1));
+}
+
+.dark\:invert:is(.dark *) {
+  --tw-invert: invert(100%);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.dark\:hover\:bg-gray-200:hover:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(228 228 231 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:hover\:bg-gray-700:hover:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(63 63 70 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:hover\:bg-primary:hover:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(var(--color-primary) / var(--tw-bg-opacity, 1));
+}
+
+.dark\:hover\:bg-red-500:hover:is(.dark *) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 68 68 / var(--tw-bg-opacity, 1));
+}
+
+.dark\:hover\:text-gray-100:hover:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(244 244 245 / var(--tw-text-opacity, 1));
+}
+
+.dark\:hover\:ring-gray-200:hover:is(.dark *) {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(228 228 231 / var(--tw-ring-opacity, 1));
+}
+
+@media (min-width: 768px) {
+
+  .md\:relative {
+    position: relative;
+  }
+
+  .md\:-ml-1 {
+    margin-left: -4px;
+  }
+
+  .md\:mb-0 {
+    margin-bottom: 0px;
+  }
+
+  .md\:ml-0 {
+    margin-left: 0px;
+  }
+
+  .md\:ml-4 {
+    margin-left: 16px;
+  }
+
+  .md\:mt-0 {
+    margin-top: 0px;
+  }
+
+  .md\:block {
+    display: block;
+  }
+
+  .md\:flex {
+    display: flex;
+  }
+
+  .md\:hidden {
+    display: none;
+  }
+
+  .md\:w-auto {
+    width: auto;
+  }
+
+  .md\:flex-1 {
+    flex: 1 1 0%;
+  }
+
+  .md\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .md\:items-center {
+    align-items: center;
+  }
+
+  .md\:justify-between {
+    justify-content: space-between;
+  }
+
+  .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
+    --tw-space-x-reverse: 0;
+    margin-right: calc(16px * var(--tw-space-x-reverse));
+    margin-left: calc(16px * calc(1 - var(--tw-space-x-reverse)));
+  }
+
+  .md\:px-4 {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .md\:pr-60 {
+    padding-right: 240px;
+  }
+
+  .md\:text-left {
+    text-align: left;
+  }
+}
+
+@media (min-width: 1024px) {
+
+  .lg\:mb-0 {
+    margin-bottom: 0px;
+  }
+
+  .lg\:ml-8 {
+    margin-left: 32px;
+  }
+
+  .lg\:mt-0 {
+    margin-top: 0px;
+  }
+
+  .lg\:block {
+    display: block;
+  }
+
+  .lg\:inline-block {
+    display: inline-block;
+  }
+
+  .lg\:flex {
+    display: flex;
+  }
+
+  .lg\:hidden {
+    display: none;
+  }
+
+  .lg\:w-4\/12 {
+    width: 33.333333%;
+  }
+
+  .lg\:w-auto {
+    width: auto;
+  }
+
+  .lg\:flex-1 {
+    flex: 1 1 0%;
+  }
+
+  .lg\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .lg\:flex-row {
+    flex-direction: row;
+  }
+
+  .lg\:items-center {
+    align-items: center;
+  }
+
+  .lg\:justify-between {
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 1536px) {
+
+  .\32xl\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+</style><style>.list-item-active svg { visibility: visible }</style><div id="app" data-v-app=""><!----></div></template></div></body></html>

--- a/tests/fixtures/WF-7720.html
+++ b/tests/fixtures/WF-7720.html
@@ -1,0 +1,222 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN ""http://www.w3.org/TR/html4/strict.dtd">
+<html>
+   <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+      <meta name="Author" content="SEIKO EPSON">
+      <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0">
+      <meta name="format-detection" content="telephone=no">
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <script type="text/javascript"><!--var current = new Date();document.write("<link rel='stylesheet' type='text/css' href='../../STYLE/PC_2016.CSS&tm=" + current.getTime() + "' media='only screen and (max-device-width:800px)'>");document.write("<link rel='stylesheet' type='text/css' href='../../STYLE/PC_2016.CSS&tm=" + current.getTime() + "' media='only screen and (min-device-width:801px)'>");document.write("<!--[if IE ]>" +"<link rel='stylesheet' type='text/css' href='../../STYLE/PC_2016.CSS&tm=" + current.getTime() + "'>" +"<![endif]-->");// --></script>
+      <noscript>
+         <link rel='stylesheet' type='text/css' href='../../STYLE/PC_2016.CSS' media='only screen and (max-device-width:800px)'>
+         <link rel='stylesheet' type='text/css' href='../../STYLE/PC_2016.CSS' media='only screen and (min-device-width:801px)'>
+         <!--[if IE ]>
+         <link rel='stylesheet' type='text/css' href='../../STYLE/PC_2016.CSS'>
+         <![endif]-->
+      </noscript>
+      <title>WF-7720 Series</title>
+      <script type="text/javascript" src="../../SCRIPT/MENT.JS"></script>
+   </head>
+   <body onload="(function(){setTimeout(function(){if(window.pageYOffset==0){window.scrollTo(0,1);}},100);})()" onunload="(function(){})()">
+      <div class="wrap">
+         <div class="header">
+            <h1 class="font-size-14em"><img class="logo" src='../../IMAGE/EPSONLOGO.PNG' width='83' height='21' alt="EPSON"><img class="separatpr" src='../../IMAGE/SEPARATOR.PNG' width='2' height='58' alt=""><span class="separatpr"></span><span class="header">WF-7720 Series</span></h1>
+         </div>
+         <div class="section">
+            <h2><img class="link-title" src='../../IMAGE/PRTINFO_ILL.PNG' width='48' height='48' alt="">Product Status</h2>
+            <table class="navi">
+               <tr>
+                  <td id="tab-item-main" class="tab-item-main-on-sprtwfd" onclick="info_main_sprtwfd()">Basic</td>
+                  <td id="tab-item-network" class="tab-item-network-off-sprtwfd" onclick="info_network_sprtwfd()">Network</td>
+                  <td id="tab-item-wfd" class="tab-item-wfd-off" onclick="info_wfd()">Wi-Fi Direct</td>
+               </tr>
+            </table>
+            <div id="info-main">
+               <div class="information-first">
+                  <form method='get' name='form_select_language' action='./PRTINFO.HTML'>
+                     <select class="list-full text" name='SEL_LANGB' onchange='return document.form_select_language.submit();'>
+                        <option value='1' selected>English</option>
+                        <option value='2' >Français</option>
+                        <option value='4' >Deutsch</option>
+                        <option value='3' >Italiano</option>
+                        <option value='5' >Español</option>
+                        <option value='6' >Português</option>
+                        <option value='7' >Nederlands</option>
+                        <option value='8' >Русский</option>
+                        <option value='12' >Norsk</option>
+                        <option value='13' >Svenska</option>
+                        <option value='14' >Suomi</option>
+                        <option value='15' >polski</option>
+                        <option value='16' >Čeština</option>
+                        <option value='17' >Magyar</option>
+                        <option value='18' >Dansk</option>
+                        <option value='19' >Türkçe</option>
+                        <option value='20' >Ελληνικά</option>
+                        <option value='21' >Slovensky</option>
+                        <option value='22' >Română</option>
+                        <option value='23' >Україна</option>
+                        <option value='10' >繁體中文</option>
+                        <option value='11' >简体中文</option>
+                        <option value='9' >한국어</option>
+                     </select>
+                  </form>
+               </div>
+               <div class="information">
+                  <fieldset id="PRT_STATUS" class="information-first clearfix">
+                     <legend class="key">Printer Status</legend>
+                     <ul class='clearfix'>
+                        <li>
+                           <div class="preserve-white-space">Available.</div>
+                        </li>
+                     </ul>
+                  </fieldset>
+                  <fieldset id="SCN_STATUS" class="information clearfix">
+                     <legend class="key">Scanner Status</legend>
+                     <ul class='clearfix'>
+                        <li><span>Available.</span></li>
+                     </ul>
+                  </fieldset>
+                  <div id="ELSE_STATUS">
+                     <fieldset class="information-last clearfix">
+                        <legend class="key">Other Status</legend>
+                        <ul class='clearfix'>
+                           <li>
+                              <noscript>
+                                 <div>Enable the browser's JavaScript setting.</div>
+                              </noscript>
+                           </li>
+                        </ul>
+                     </fieldset>
+                  </div>
+               </div>
+               <script type="text/javascript"><!--$NHideElseStatus();//-->$N</script>
+               <div class="information-last clearfix">
+                  <ul class="inksection">
+                     <li class='tank'>
+                        <div class='tank'><img class='color' src='../../IMAGE/Ink_K.PNG' height='48' style=''></div>
+                        <div class='clrname'>BK</div>
+                     </li>
+                     <!---->
+                     <li class='tank'>
+                        <div class='tank'><img class='color' src='../../IMAGE/Ink_C.PNG' height='32' style=''></div>
+                        <div class='clrname'>C</div>
+                     </li>
+                     <!---->
+                     <li class='tank'>
+                        <div class='tank'><img class='color' src='../../IMAGE/Ink_M.PNG' height='44' style=''></div>
+                        <div class='clrname'>M</div>
+                     </li>
+                     <!---->
+                     <li class='tank'>
+                        <div class='tank'><img class='color' src='../../IMAGE/Ink_Y.PNG' height='38' style=''></div>
+                        <div class='clrname'>Y</div>
+                     </li>
+                     <!---->
+                     <li class='tank'>
+                        <div class='tank'><img class='color' src='../../IMAGE/Ink_Waste.PNG' height='44' style=''></div>
+                        <div class='mbicn'><img src='../../IMAGE/Icn_Mb.PNG' height='18' width='18'></div>
+                     </li>
+                  </ul>
+               </div>
+            </div>
+            <div id="info-network">
+               <table style="border-collapse: collapse; width: 100%;">
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Device Name</bdi>&nbsp;:</td>
+                     <td class="item-value">EPSON06274A</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Connection Status</bdi>&nbsp;:</td>
+                     <td class="item-value">Wi-Fi-72Mbps</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Signal Strength</bdi>&nbsp;:</td>
+                     <td class="item-value">Excellent</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Obtain IP Address</bdi>&nbsp;:</td>
+                     <td class="item-value">Auto</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>IP Address</bdi>&nbsp;:</td>
+                     <td class="item-value">192.168.2.121</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Subnet Mask</bdi>&nbsp;:</td>
+                     <td class="item-value">255.255.255.0</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Default Gateway</bdi>&nbsp;:</td>
+                     <td class="item-value">192.168.2.1</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>DNS Server Setting</bdi>&nbsp;:</td>
+                     <td class="item-value">Auto</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Primary DNS Server</bdi>&nbsp;:</td>
+                     <td class="item-value">192.168.2.200</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Secondary DNS Server</bdi>&nbsp;:</td>
+                     <td class="item-value">&nbsp;</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Proxy Server</bdi>&nbsp;:</td>
+                     <td class="item-value">Do Not Use</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Wi-Fi Setup</bdi>&nbsp;:</td>
+                     <td class="item-value">Manual</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>SSID</bdi>&nbsp;:</td>
+                     <td class="item-value">knappe-home</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Security Level</bdi>&nbsp;:</td>
+                     <td class="item-value">WPA2-PSK(AES)</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Password</bdi>&nbsp;:</td>
+                     <td class="item-value">**********</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>File Sharing</bdi>&nbsp;:</td>
+                     <td class="item-value">Enable</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>File Sharing Mode</bdi>&nbsp;:</td>
+                     <td class="item-value">Read Only</td>
+                  </tr>
+                  <tr class="item-last clearfix">
+                     <td class="item-key"><bdi>MAC Address</bdi>&nbsp;:</td>
+                     <td class="item-value">38:1A:52:06:27:4A</td>
+                  </tr>
+               </table>
+            </div>
+            <div id="info-wfd">
+               <table style="border-collapse: collapse; width: 100%;">
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Device Name</bdi>&nbsp;:</td>
+                     <td class="item-value">EPSON06274A</td>
+                  </tr>
+                  <tr class="item clearfix">
+                     <td class="item-key"><bdi>Connection Method</bdi>&nbsp;:</td>
+                     <td class="item-value">Not Set</td>
+                  </tr>
+               </table>
+            </div>
+         </div>
+         <ul class="with-padding clearfix">
+            <li id="button-latest" class="list"><a class="button" href="javascript:void(0)" onclick="javascript:update(); return false;">Refresh</a></li>
+            <noscript>
+               <li class="list"><a class="button" href="./PRTINFO.HTML">Refresh</a></li>
+            </noscript>
+            <li class="list-last"><a class="button" href="./INDEX.html">Back to Main</a></li>
+         </ul>
+         <ul><a class="license" target="_blank" href="/PRESENTATION/ADVANCED/LICENSE/TOP">Software Licenses</a></ul>
+      </div>
+      <script type="text/javascript"><!--initialize();//--></script>
+   </body>
+</HTML>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 """Tests for EpsonWorkForceAPI using only the public API (no soup poking)."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from custom_components.epson_workforce.api import EpsonWorkForceAPI
 
@@ -100,81 +100,6 @@ class TestEpsonWorkForceAPI:
         """
         api = api_from_html(html)
         assert api.get_sensor_value("printer_status") == "Ready"
-
-    def test_information_div_structure_variations(self):
-        html = "<html><body><div class='information'><span>Available</span></div></body></html>"
-        api = api_from_html(html)
-        assert api.get_sensor_value("printer_status") == "Available"
-
-        html = """
-        <html>
-          <body>
-            <div class="information">
-              <p class="clearfix">
-                <span>Printing.</span>
-                <span>Page 1 of 5</span>
-              </p>
-            </div>
-          </body>
-        </html>
-        """
-        api = api_from_html(html)
-        assert api.get_sensor_value("printer_status") == "Printing"
-
-    # -------------------------
-    # Ink levels (your original HTML using <div height="...">)
-    # -------------------------
-    def test_ink_level_sensors(self):
-        html = """
-        <html>
-          <body>
-            <ul>
-              <li class="tank"><div class="clrname">BK</div><div class="tank"><div height="45"></div></div></li>
-              <li class="tank"><div class="clrname">C</div><div class="tank"><div height="30"></div></div></li>
-              <li class="tank"><div class="clrname">M</div><div class="tank"><div height="25"></div></div></li>
-              <li class="tank"><div class="clrname">Y</div><div class="tank"><div height="40"></div></div></li>
-            </ul>
-          </body>
-        </html>
-        """
-        api = api_from_html(html)
-        assert api.get_sensor_value("black") == 90
-        assert api.get_sensor_value("cyan") == 60
-        assert api.get_sensor_value("magenta") == 50
-        assert api.get_sensor_value("yellow") == 80
-
-    def test_photo_ink_sensors(self):
-        html = """
-        <html>
-          <body>
-            <ul>
-              <li class="tank"><div class="clrname">PB</div><div class="tank"><div height="35"></div></div></li>
-              <li class="tank"><div class="clrname">LC</div><div class="tank"><div height="20"></div></div></li>
-              <li class="tank"><div class="clrname">LM</div><div class="tank"><div height="15"></div></div></li>
-            </ul>
-          </body>
-        </html>
-        """
-        api = api_from_html(html)
-        assert api.get_sensor_value("photoblack") == 70
-        assert api.get_sensor_value("lightcyan") == 40
-        assert api.get_sensor_value("lightmagenta") == 30
-
-    def test_waste_tank_sensor(self):
-        html = """
-        <html>
-          <body>
-            <ul>
-              <li class="tank">
-                <div class="mbicn">Waste</div>
-                <div class="tank"><div height="10"></div></div>
-              </li>
-            </ul>
-          </body>
-        </html>
-        """
-        api = api_from_html(html)
-        assert api.get_sensor_value("clean") == 20
 
     # -------------------------
     # Invalid/malformed inputs

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,7 +118,7 @@ class TestEpsonWorkForceAPI:
         </ul></body></html>
         """
         api = api_from_html(html)
-        assert api.get_sensor_value("black") is None
+        assert api.get_sensor_value("BK") is None
 
         # Missing inner tank
         html = """
@@ -127,7 +127,7 @@ class TestEpsonWorkForceAPI:
         </ul></body></html>
         """
         api = api_from_html(html)
-        assert api.get_sensor_value("black") is None
+        assert api.get_sensor_value("BK") is None
 
     # -------------------------
     # Device info extraction
@@ -167,7 +167,7 @@ class TestEpsonWorkForceAPI:
         with patch("urllib.request.urlopen", side_effect=Exception("offline")):
             api = EpsonWorkForceAPI("127.0.0.1", "/test")
         assert api.get_sensor_value("printer_status") == "Unknown"
-        assert api.get_sensor_value("black") is None
+        assert api.get_sensor_value("BK") is None
         assert api.model == "WorkForce Printer"
         assert api.mac_address is None
 
@@ -179,7 +179,7 @@ class TestEpsonWorkForceAPI:
         </ul></body></html>
         """
         api = api_from_html(html)
-        assert api.get_sensor_value("black") is None
+        assert api.get_sensor_value("BK") is None
 
         # Wrong class names
         html = """
@@ -188,7 +188,7 @@ class TestEpsonWorkForceAPI:
         </ul></body></html>
         """
         api = api_from_html(html)
-        assert api.get_sensor_value("black") is None
+        assert api.get_sensor_value("BK") is None
 
         # Non-numeric height
         html = """
@@ -197,7 +197,7 @@ class TestEpsonWorkForceAPI:
         </ul></body></html>
         """
         api = api_from_html(html)
-        assert api.get_sensor_value("black") is None
+        assert api.get_sensor_value("BK") is None
 
         # Missing everything
         html = "<html><body></body></html>"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,494 +1,280 @@
-"""Test the Epson WorkForce API."""
+"""Tests for EpsonWorkForceAPI using only the public API (no soup poking)."""
 
-import pytest
-from bs4 import BeautifulSoup
 from unittest.mock import patch, MagicMock
 
 from custom_components.epson_workforce.api import EpsonWorkForceAPI
 
+
+# Helper: build an API instance whose update() reads our provided HTML
+def api_from_html(html: str) -> EpsonWorkForceAPI:
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = html.encode("utf-8")
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+        api = EpsonWorkForceAPI("127.0.0.1", "/test")
+        api.update()
+        api._ensure_parsed()
+    return api
+
+
 class TestEpsonWorkForceAPI:
-    """Test class for EpsonWorkForceAPI."""
-
-    def setup_method(self):
-        """Set up test fixtures."""
-        # Mock the update method to avoid network calls
-        with patch.object(EpsonWorkForceAPI, 'update'):
-            self.api = EpsonWorkForceAPI("192.168.1.100", "/PRESENTATION/HTML/TOP/PRTINFO.HTML")
-
-    def test_printer_status_primary_structure(self):
-        """Test printer status parsing with primary HTML structure."""
-        # Test case 1: Available status
-        html = """
-        <html>
-            <body>
-                <fieldset id="PRT_STATUS">
-                    <ul>Available.</ul>
-                </fieldset>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Available"
-
-        # Test case 2: Ready status
-        html = """
-        <html>
-            <body>
-                <fieldset id="PRT_STATUS">
-                    <ul>Ready</ul>
-                </fieldset>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Ready"
-
-        # Test case 3: Error status with period removal
-        html = """
-        <html>
-            <body>
-                <fieldset id="PRT_STATUS">
-                    <ul>Paper jam.</ul>
-                </fieldset>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Paper jam"
-
-        # Test case 4: Long status (should not remove period)
-        html = """
-        <html>
-            <body>
-                <fieldset id="PRT_STATUS">
-                    <ul>This is a very long status message that exceeds thirty characters.</ul>
-                </fieldset>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "This is a very long status message that exceeds thirty characters."
-
-    def test_printer_status_fallback_structure(self):
-        """Test printer status parsing with fallback HTML structure."""
-        # Test case 1: Standard fallback structure
-        html = """
-        <html>
-            <body>
-                <div class="information">
-                    <p class="clearfix">
-                        <span>Available.</span>
-                    </p>
-                </div>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Available"
-
-        # Test case 2: Fallback without clearfix class
-        html = """
-        <html>
-            <body>
-                <div class="information">
-                    <span>Ready</span>
-                </div>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Ready"
-
-        # Test case 3: Multiple spans - should pick first one
-        html = """
-        <html>
-            <body>
-                <div class="information">
-                    <p class="clearfix">
-                        <span>Printing.</span>
-                        <span>Page 1 of 5</span>
-                    </p>
-                </div>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Printing"
-
-    def test_printer_status_priority_order(self):
-        """Test that primary structure takes priority over fallback."""
-        html = """
-        <html>
-            <body>
-                <fieldset id="PRT_STATUS">
-                    <ul>Primary Status</ul>
-                </fieldset>
-                <div class="information">
-                    <p class="clearfix">
-                        <span>Fallback Status</span>
-                    </p>
-                </div>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Primary Status"
-
-    def test_printer_status_missing_elements(self):
-        """Test printer status with missing or malformed elements."""
-        # Test case 1: Missing fieldset
-        html = """
-        <html>
-            <body>
-                <div class="information">
-                    <p class="clearfix">
-                        <span>Available.</span>
-                    </p>
-                </div>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Available"
-
-        # Test case 2: Empty fieldset, fallback works
-        html = """
-        <html>
-            <body>
-                <fieldset id="PRT_STATUS">
-                </fieldset>
-                <div class="information">
-                    <span>Fallback Works</span>
-                </div>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Fallback Works"
-
-        # Test case 3: Neither structure present
-        html = """
-        <html>
-            <body>
-                <div>Some other content</div>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Unknown"
-
-    def test_ink_level_sensors(self):
-        """Test ink level sensor parsing."""
-        # Test case: Standard ink tank structure
-        html = """
-        <html>
-            <body>
-                <ul>
-                    <li class="tank">
-                        <div class="clrname">BK</div>
-                        <div class="tank">
-                            <div height="45"></div>
-                        </div>
-                    </li>
-                    <li class="tank">
-                        <div class="clrname">C</div>
-                        <div class="tank">
-                            <div height="30"></div>
-                        </div>
-                    </li>
-                    <li class="tank">
-                        <div class="clrname">M</div>
-                        <div class="tank">
-                            <div height="25"></div>
-                        </div>
-                    </li>
-                    <li class="tank">
-                        <div class="clrname">Y</div>
-                        <div class="tank">
-                            <div height="40"></div>
-                        </div>
-                    </li>
-                </ul>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-
-        # Test black ink
-        black_level = self.api.get_sensor_value("black")
-        assert black_level == 90  # 45 * 2
-
-        # Test cyan ink
-        cyan_level = self.api.get_sensor_value("cyan")
-        assert cyan_level == 60  # 30 * 2
-
-        # Test magenta ink
-        magenta_level = self.api.get_sensor_value("magenta")
-        assert magenta_level == 50  # 25 * 2
-
-        # Test yellow ink
-        yellow_level = self.api.get_sensor_value("yellow")
-        assert yellow_level == 80  # 40 * 2
-
-    def test_photo_ink_sensors(self):
-        """Test photo ink sensor parsing (PB, LC, LM)."""
-        html = """
-        <html>
-            <body>
-                <ul>
-                    <li class="tank">
-                        <div class="clrname">PB</div>
-                        <div class="tank">
-                            <div height="35"></div>
-                        </div>
-                    </li>
-                    <li class="tank">
-                        <div class="clrname">LC</div>
-                        <div class="tank">
-                            <div height="20"></div>
-                        </div>
-                    </li>
-                    <li class="tank">
-                        <div class="clrname">LM</div>
-                        <div class="tank">
-                            <div height="15"></div>
-                        </div>
-                    </li>
-                </ul>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-
-        # Test photo black ink
-        pb_level = self.api.get_sensor_value("photoblack")
-        assert pb_level == 70  # 35 * 2
-
-        # Test light cyan ink
-        lc_level = self.api.get_sensor_value("lightcyan")
-        assert lc_level == 40  # 20 * 2
-
-        # Test light magenta ink
-        lm_level = self.api.get_sensor_value("lightmagenta")
-        assert lm_level == 30  # 15 * 2
-
-    def test_waste_tank_sensor(self):
-        """Test waste tank sensor parsing."""
-        html = """
-        <html>
-            <body>
-                <ul>
-                    <li class="tank">
-                        <div class="mbicn">Waste</div>
-                        <div class="tank">
-                            <div height="10"></div>
-                        </div>
-                    </li>
-                </ul>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-
-        # Test waste tank level
-        waste_level = self.api.get_sensor_value("clean")
-        assert waste_level == 20  # 10 * 2
-
-    def test_invalid_sensor_types(self):
-        """Test handling of invalid sensor types."""
-        html = """<html><body></body></html>"""
-        self.api.soup = BeautifulSoup(html, "html.parser")
-
-        # Test unknown sensor type
-        result = self.api.get_sensor_value("unknown_sensor")
-        assert result is None
-
-        # Test None sensor type
-        result = self.api.get_sensor_value(None)
-        assert result is None
-
-    def test_malformed_ink_structure(self):
-        """Test handling of malformed ink level HTML."""
-        # Test case 1: Missing height attribute
-        html = """
-        <html>
-            <body>
-                <ul>
-                    <li class="tank">
-                        <div class="clrname">BK</div>
-                        <div class="tank">
-                            <div></div>
-                        </div>
-                    </li>
-                </ul>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        black_level = self.api.get_sensor_value("black")
-        assert black_level is None
-
-        # Test case 2: Missing tank div
-        html = """
-        <html>
-            <body>
-                <ul>
-                    <li class="tank">
-                        <div class="clrname">BK</div>
-                    </li>
-                </ul>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        black_level = self.api.get_sensor_value("black")
-        assert black_level is None
-
-    def test_device_info_extraction(self):
-        """Test device information extraction."""
-        html = """
-        <html>
-            <head>
-                <title>ET-8500 Series</title>
-            </head>
-            <body>
-                <div>
-                    <p>MAC Address: 12:34:56:78:90:AB</p>
-                </div>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        self.api._extract_device_info()
-
-        assert self.api.model == "Epson ET-8500 Series"
-        assert self.api.mac_address == "12:34:56:78:90:AB"
-
-    def test_device_info_extraction_variations(self):
-        """Test device information extraction with various formats."""
-        # Test MAC address with different formatting
-        html = """
-        <html>
-            <head>
-                <title>WF-3720 Series</title>
-            </head>
-            <body>
-                <div>
-                    Some text
-                    MAC Address : AA:BB:CC:DD:EE:FF
-                    More text
-                </div>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        self.api._extract_device_info()
-
-        assert self.api.model == "Epson WF-3720 Series"
-        assert self.api.mac_address == "AA:BB:CC:DD:EE:FF"
-
-    def test_exception_handling(self):
-        """Test exception handling in various scenarios."""
-        # Test printer status with None soup
-        self.api.soup = None
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Unknown"
-
-        # Test ink level with None soup
-        ink_level = self.api.get_sensor_value("black")
-        assert ink_level is None
-
-        # Test device info extraction with None soup
-        self.api.soup = None
-        self.api._extract_device_info()
-        assert self.api.model == "WorkForce Printer"
-        assert self.api.mac_address is None
-
     def test_update_method_failure(self):
-        """Test API update method failure handling."""
-        # Test that update method sets available to False on exception
-        with patch('urllib.request.urlopen', side_effect=Exception("Network error")):
-            api = EpsonWorkForceAPI("192.168.1.100", "/test")
+        with patch("urllib.request.urlopen", side_effect=Exception("Network error")):
+            api = EpsonWorkForceAPI("127.0.0.1", "/test")
             assert api.available is False
 
     def test_update_method_success(self):
-        """Test API update method success."""
-        mock_response = MagicMock()
-        mock_response.read.return_value = b"<html><body><title>Test</title></body></html>"
+        api = api_from_html("<html><body><title>Test</title></body></html>")
+        assert api.available is True
+        # soup is an implementation detail; we only check API behavior here
+        assert isinstance(api.model, str)
 
-        with patch('urllib.request.urlopen') as mock_urlopen:
-            mock_urlopen.return_value.__enter__.return_value = mock_response
-            api = EpsonWorkForceAPI("192.168.1.100", "/test")
-            assert api.available is True
-            assert api.soup is not None
+    # -------------------------
+    # Status parsing
+    # -------------------------
+    def test_printer_status_priority_order(self):
+        html = """
+        <html>
+          <body>
+            <fieldset id="PRT_STATUS"><ul>Primary Status</ul></fieldset>
+            <div class="information"><p class="clearfix"><span>Fallback Status</span></p></div>
+          </body>
+        </html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Primary Status"
+
+    def test_printer_status_missing_elements(self):
+        html = """
+        <html>
+          <body>
+            <div class="information"><p class="clearfix"><span>Available.</span></p></div>
+          </body>
+        </html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Available"
+
+        html = """
+        <html>
+          <body>
+            <fieldset id="PRT_STATUS"></fieldset>
+            <div class="information"><span>Fallback Works</span></div>
+          </body>
+        </html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Fallback Works"
+
+        html = "<html><body><div>Other content</div></body></html>"
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Unknown"
 
     def test_edge_case_empty_status(self):
-        """Test edge cases with empty or whitespace status."""
-        # Test empty ul content - returns "Unknown" since ul exists but has no text
-        html = """
-        <html>
-            <body>
-                <fieldset id="PRT_STATUS">
-                    <ul></ul>
-                </fieldset>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Unknown"
+        html = (
+            "<html><body><fieldset id='PRT_STATUS'><ul></ul></fieldset></body></html>"
+        )
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Unknown"
 
-        # Test whitespace-only content - returns "Unknown" after strip()
-        html = """
-        <html>
-            <body>
-                <fieldset id="PRT_STATUS">
-                    <ul>   </ul>
-                </fieldset>
-            </body>
-        </html>
-        """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Unknown"
+        html = "<html><body><fieldset id='PRT_STATUS'><ul>   </ul></fieldset></body></html>"
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Unknown"
 
-        # Test empty span in fallback structure
         html = """
-        <html>
-            <body>
-                <div class="information">
-                    <p class="clearfix">
-                        <span></span>
-                    </p>
-                </div>
-            </body>
-        </html>
+        <html><body><div class="information"><p class="clearfix"><span></span></p></div></body></html>
         """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Unknown"
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Unknown"
 
-        # Test whitespace-only span in fallback structure
+        html = (
+            "<html><body><div class='information'><span>   </span></div></body></html>"
+        )
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Unknown"
+
+    def test_strip_trailing_period_short_status(self):
+        html = """
+        <html><body><div class="information"><p class="clearfix"><span>Ready.</span></p></div></body></html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Ready"
+
+    def test_information_div_structure_variations(self):
+        html = "<html><body><div class='information'><span>Available</span></div></body></html>"
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Available"
+
         html = """
         <html>
-            <body>
-                <div class="information">
-                    <span>   </span>
-                </div>
-            </body>
+          <body>
+            <div class="information">
+              <p class="clearfix">
+                <span>Printing.</span>
+                <span>Page 1 of 5</span>
+              </p>
+            </div>
+          </body>
         </html>
         """
-        self.api.soup = BeautifulSoup(html, "html.parser")
-        status = self.api.get_sensor_value("printer_status")
-        assert status == "Unknown"
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Printing"
+
+    # -------------------------
+    # Ink levels (your original HTML using <div height="...">)
+    # -------------------------
+    def test_ink_level_sensors(self):
+        html = """
+        <html>
+          <body>
+            <ul>
+              <li class="tank"><div class="clrname">BK</div><div class="tank"><div height="45"></div></div></li>
+              <li class="tank"><div class="clrname">C</div><div class="tank"><div height="30"></div></div></li>
+              <li class="tank"><div class="clrname">M</div><div class="tank"><div height="25"></div></div></li>
+              <li class="tank"><div class="clrname">Y</div><div class="tank"><div height="40"></div></div></li>
+            </ul>
+          </body>
+        </html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("black") == 90
+        assert api.get_sensor_value("cyan") == 60
+        assert api.get_sensor_value("magenta") == 50
+        assert api.get_sensor_value("yellow") == 80
+
+    def test_photo_ink_sensors(self):
+        html = """
+        <html>
+          <body>
+            <ul>
+              <li class="tank"><div class="clrname">PB</div><div class="tank"><div height="35"></div></div></li>
+              <li class="tank"><div class="clrname">LC</div><div class="tank"><div height="20"></div></div></li>
+              <li class="tank"><div class="clrname">LM</div><div class="tank"><div height="15"></div></div></li>
+            </ul>
+          </body>
+        </html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("photoblack") == 70
+        assert api.get_sensor_value("lightcyan") == 40
+        assert api.get_sensor_value("lightmagenta") == 30
+
+    def test_waste_tank_sensor(self):
+        html = """
+        <html>
+          <body>
+            <ul>
+              <li class="tank">
+                <div class="mbicn">Waste</div>
+                <div class="tank"><div height="10"></div></div>
+              </li>
+            </ul>
+          </body>
+        </html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("clean") == 20
+
+    # -------------------------
+    # Invalid/malformed inputs
+    # -------------------------
+    def test_invalid_sensor_types(self):
+        html = "<html><body></body></html>"
+        api = api_from_html(html)
+        assert api.get_sensor_value("unknown_sensor") is None
+        assert api.get_sensor_value(None) is None  # type: ignore[arg-type]
+
+    def test_malformed_ink_structure(self):
+        # Missing height attribute
+        html = """
+        <html><body><ul>
+          <li class="tank"><div class="clrname">BK</div><div class="tank"><div></div></div></li>
+        </ul></body></html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("black") is None
+
+        # Missing inner tank
+        html = """
+        <html><body><ul>
+          <li class="tank"><div class="clrname">BK</div></li>
+        </ul></body></html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("black") is None
+
+    # -------------------------
+    # Device info extraction
+    # -------------------------
+    def test_device_info_extraction(self):
+        html = """
+        <html>
+          <head><title>ET-8500 Series</title></head>
+          <body><div><p>MAC Address: 12:34:56:78:90:AB</p></div></body>
+        </html>
+        """
+        api = api_from_html(html)
+        # model/mac exposed via public properties
+        assert api.model == "Epson ET-8500 Series"
+        assert api.mac_address == "12:34:56:78:90:AB"
+
+    def test_device_info_extraction_variations(self):
+        html = """
+        <html>
+          <head><title>WF-3720 Series</title></head>
+          <body>
+            Some text
+            MAC Address : AA:BB:CC:DD:EE:FF
+            More text
+          </body>
+        </html>
+        """
+        api = api_from_html(html)
+        assert api.model == "Epson WF-3720 Series"
+        assert api.mac_address == "AA:BB:CC:DD:EE:FF"
+
+    # -------------------------
+    # Exception / None soup
+    # -------------------------
+    def test_exception_handling(self):
+        # Simulate offline by constructing, then breaking update()
+        with patch("urllib.request.urlopen", side_effect=Exception("offline")):
+            api = EpsonWorkForceAPI("127.0.0.1", "/test")
+        assert api.get_sensor_value("printer_status") == "Unknown"
+        assert api.get_sensor_value("black") is None
+        assert api.model == "WorkForce Printer"
+        assert api.mac_address is None
+
+    def test_unexpected_html_structure(self):
+        # No clrname but has a height → not attributable to a color key
+        html = """
+        <html><body><ul>
+          <li class="tank"><div class="tank"><div style="height:25px;"></div></div></li>
+        </ul></body></html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("black") is None
+
+        # Wrong class names
+        html = """
+        <html><body><ul>
+          <li class="container"><div class="colorname">BK</div><div class="bar"><div style="height:30px;"></div></div></li>
+        </ul></body></html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("black") is None
+
+        # Non-numeric height
+        html = """
+        <html><body><ul>
+          <li class="tank"><div class="clrname">BK</div><div class="tank"><div style="height:abc;"></div></div></li>
+        </ul></body></html>
+        """
+        api = api_from_html(html)
+        assert api.get_sensor_value("black") is None
+
+        # Missing everything
+        html = "<html><body></body></html>"
+        api = api_from_html(html)
+        assert api.get_sensor_value("printer_status") == "Unknown"


### PR DESCRIPTION
- Split HTML parsing into a separate class that is compatible with all currently known status page formats.
- Simplify the API to HTTP retrieval and calling the HTML parser.
- Refactor tests based on saved status pages (fixtures) and add more of them.
- Remove API tests that were redundant with the fixture-based testing.

The new HTML parser is largely generated by ChatGPT, so if it works I'll take credit for using ChatGPT otherwise boo ChatGPT!