### PR TITLE
Added detailed usage statistics (printed pages and scan counters)

### DIFF
--- a/custom_components/epson_workforce/api.py
+++ b/custom_components/epson_workforce/api.py
@@ -79,9 +79,9 @@ class EpsonWorkForceAPI:
         
         patterns = {
             "total_pages": r"Total Number of Pages.*?>(\d+)</div>",
-            "bw_pages": r"Total Number of B(?:&amp;|W) Pages.*?>(\d+)</div>",
-            "color_pages": r"Total Number of Color Pages.*?>(\d+)</div>",
-            "bw_scans": r"B(?:&amp;|W) Scan.*?>(\d+)</div>",
+            "bw_pages": r"B.*?W.*?Pages.*?>(\d+)</div>",
+            "color_pages": r"Color Pages.*?>(\d+)</div>",
+            "bw_scans": r"B.*?W.*?Scan.*?>(\d+)</div>",
             "color_scans": r"Color Scan.*?>(\d+)</div>",
             "first_print_date": r"First Printing Date.*?>([\d-]+)</div>",
         }

--- a/custom_components/epson_workforce/api.py
+++ b/custom_components/epson_workforce/api.py
@@ -78,12 +78,12 @@ class EpsonWorkForceAPI:
         ]
         
         patterns = {
-            "total_pages": r"Total Number of Pages.*?class=\"preserve-white-space\">(.*?)</div>",
-            "bw_pages": r"Total Number of B&W Pages.*?class=\"preserve-white-space\">(.*?)</div>",
-            "color_pages": r"Total Number of Color Pages.*?class=\"preserve-white-space\">(.*?)</div>",
-            "bw_scans": r"B&W Scan.*?class=\"preserve-white-space\">(.*?)</div>",
-            "color_scans": r"Color Scan.*?class=\"preserve-white-space\">(.*?)</div>",
-            "first_print_date": r"First Printing Date.*?class=\"preserve-white-space\">(.*?)</div>",
+            "total_pages": r"Total Number of Pages.*?>(\d+)</div>",
+            "bw_pages": r"Total Number of B(?:&amp;|W) Pages.*?>(\d+)</div>",
+            "color_pages": r"Total Number of Color Pages.*?>(\d+)</div>",
+            "bw_scans": r"B(?:&amp;|W) Scan.*?>(\d+)</div>",
+            "color_scans": r"Color Scan.*?>(\d+)</div>",
+            "first_print_date": r"First Printing Date.*?>([\d-]+)</div>",
         }
 
         for path in possible_paths:
@@ -91,13 +91,16 @@ class EpsonWorkForceAPI:
                 url = f"http://{self._ip}{path}"
                 with urllib.request.urlopen(url, context=context, timeout=self._timeout) as response:
                     html = response.read().decode("utf-8", errors="ignore")
-                    found_any = False
+                    
+                    # Debug: logging can be added here if needed
+                    found_on_this_page = False
                     for key, pattern in patterns.items():
                         match = re.search(pattern, html, re.DOTALL | re.IGNORECASE)
                         if match:
                             self._usage_data[key] = match.group(1).strip()
-                            found_any = True
-                    if found_any:
+                            found_on_this_page = True
+                    
+                    if found_on_this_page:
                         break
             except Exception:
                 continue

--- a/custom_components/epson_workforce/sensor.py
+++ b/custom_components/epson_workforce/sensor.py
@@ -109,6 +109,36 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         icon="mdi:connection",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    SensorEntityDescription(  # type: ignore[call-arg]
+        key="total_pages",
+        name="Total Pages",
+        icon="mdi:counter",
+    ),
+    SensorEntityDescription(  # type: ignore[call-arg]
+        key="bw_pages",
+        name="B&W Pages",
+        icon="mdi:printer-3d-nozzle",
+    ),
+    SensorEntityDescription(  # type: ignore[call-arg]
+        key="color_pages",
+        name="Color Pages",
+        icon="mdi:palette",
+    ),
+    SensorEntityDescription(  # type: ignore[call-arg]
+        key="bw_scans",
+        name="B&W Scans",
+        icon="mdi:scanner",
+    ),
+    SensorEntityDescription(  # type: ignore[call-arg]
+        key="color_scans",
+        name="Color Scans",
+        icon="mdi:scanner-color",
+    ),
+    SensorEntityDescription(  # type: ignore[call-arg]
+        key="first_print_date",
+        name="First Printing Date",
+        icon="mdi:calendar-import",
+    ),
 )
 
 SCAN_INTERVAL = timedelta(seconds=60)


### PR DESCRIPTION
## Description
This PR adds new diagnostic and usage sensors for Epson WorkForce printers (tested on L3150 Series). It introduces a multi-path discovery mechanism to fetch data from advanced status pages that are not available on the default index page.

## New Sensors Added:
- **Total Pages**: Cumulative print count.
- **B&W Pages**: Number of black and white pages printed.
- **Color Pages**: Number of color pages printed.
- **B&W Scans**: Cumulative black and white scan count.
- **Color Scans**: Cumulative color scan count.
- **First Printing Date**: The date the printer was first used.

## Changes:
- **api.py**: Added `_fetch_usage_data` method using robust regex to parse `&amp;` encoded HTML and various Epson-specific path patterns (`/PRESENTATION/ADVANCED/COMMON/TOP`).
- **sensor.py**: Defined new `SensorEntityDescription` objects and updated the sensor discovery logic to automatically add these sensors if the data is available.

The regex patterns used are flexible enough to handle various HTML encodings (like `&amp;` and `&nbsp;`) found in different Epson firmware versions.