### PR TITLE
Fix Epson ink level parsing for gradient tanks

### DIFF
--- a/custom_components/epson_workforce/parser.py
+++ b/custom_components/epson_workforce/parser.py
@@ -194,19 +194,16 @@ class EpsonHTMLParser:
 
         style_val = bar_div.get("style")
         if style_val:
-            style = " ".join(style_val) if isinstance(style_val, list) else str(style_val)
+            style = (
+                " ".join(style_val) if isinstance(style_val, list) else str(style_val)
+            )
             s = style.lower()
 
             # Prefer the level from linear gradient.
             # Some printers put a low-ink warning icon inside the tank
             # which must not be mistaken for the ink level.
             if "linear-gradient" in s:
-                nums = [
-                    float(n)
-                    for n in re.findall(
-                        r"(\d{1,3}(?:\.\d+)?)\s*%", s
-                    )
-                ]
+                nums = [float(n) for n in re.findall(r"(\d{1,3}(?:\.\d+)?)\s*%", s)]
                 if len(nums) >= 2:
                     val = int(round(nums[1]))
                     return max(0, min(100, val))

--- a/custom_components/epson_workforce/parser.py
+++ b/custom_components/epson_workforce/parser.py
@@ -204,7 +204,7 @@ class EpsonHTMLParser:
             # which must not be mistaken for the ink level.
             if "linear-gradient" in s:
                 nums = [float(n) for n in re.findall(r"(\d{1,3}(?:\.\d+)?)\s*%", s)]
-                if len(nums) >= 2:
+                if len(nums) >= 2:  # noqa: PLR2004
                     val = int(round(nums[1]))
                     return max(0, min(100, val))
 
@@ -212,7 +212,7 @@ class EpsonHTMLParser:
             m = re.search(r"height\s*:\s*(\d+)", s)
             if m:
                 px = int(m.group(1))
-                return max(0, min(100, px * 2))
+                return max(0, min(100, px * 2))  # 50px → 100%
 
         # Fallback for printers where the level is represented by image height.
         img = bar_div.find("img")

--- a/custom_components/epson_workforce/parser.py
+++ b/custom_components/epson_workforce/parser.py
@@ -188,36 +188,42 @@ class EpsonHTMLParser:
             if any(c.lower() == "tank" for c in _classes(d)):
                 bar_div = d
                 break
+
         if bar_div is None:
             return None
 
-        # get level from image height
+        style_val = bar_div.get("style")
+        if style_val:
+            style = " ".join(style_val) if isinstance(style_val, list) else str(style_val)
+            s = style.lower()
+
+            # Prefer the level from linear gradient.
+            # Some printers put a low-ink warning icon inside the tank
+            # which must not be mistaken for the ink level.
+            if "linear-gradient" in s:
+                nums = [
+                    float(n)
+                    for n in re.findall(
+                        r"(\d{1,3}(?:\.\d+)?)\s*%", s
+                    )
+                ]
+                if len(nums) >= 2:
+                    val = int(round(nums[1]))
+                    return max(0, min(100, val))
+
+            # Fallback: get level from height in style.
+            m = re.search(r"height\s*:\s*(\d+)", s)
+            if m:
+                px = int(m.group(1))
+                return max(0, min(100, px * 2))
+
+        # Fallback for printers where the level is represented by image height.
         img = bar_div.find("img")
         if isinstance(img, Tag):
             h = img.get("height")
             if isinstance(h, str) and h.isdigit():
                 px = int(h)
                 return max(0, min(100, px * 2))
-
-        style_val = bar_div.get("style")
-        if not style_val:
-            return None
-
-        style = " ".join(style_val) if isinstance(style_val, list) else str(style_val)
-        s = style.lower()
-
-        # get level from height in style
-        m = re.search(r"height\s*:\s*(\d+)", s)
-        if m:
-            px = int(m.group(1))
-            return max(0, min(100, px * 2))  # 50px → 100%
-
-        # get level from linear gradient in style
-        if "linear-gradient" in s:
-            nums = [float(n) for n in re.findall(r"(\d{1,3}(?:\.\d+)?)\s*%", s)]
-            if len(nums) >= 2:  # noqa: PLR2004
-                val = int(round(nums[1]))
-                return max(0, min(100, val))
 
         return None
 

--- a/tests/fixtures/WF-2930.html
+++ b/tests/fixtures/WF-2930.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN " "http://www.w3.org/TR/html4/strict.dtd">
+<!-- saved from url=(0055)https://192.168.1.25/PRESENTATION/HTML/TOP/PRTINFO.HTML -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<meta name="Author" content="SEIKO EPSON">
+<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0">
+<meta name="format-detection" content="telephone=no">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<script type="text/javascript"><!--
+var current = new Date();
+document.write("<link rel='stylesheet' type='text/css' href='../../STYLE/SMT.CSS&tm=" + current.getTime() + "' media='only screen and (max-device-width:800px)'>");
+document.write("<link rel='stylesheet' type='text/css' href='../../STYLE/PC.CSS&tm=" + current.getTime() + "' media='only screen and (min-device-width:801px)'>");
+document.write("<!--[if IE ]>" +"<link rel='stylesheet' type='text/css' href='../../STYLE/PC.CSS&tm=" + current.getTime() + "'>" +"<![endif]-->");
+// --></script><link rel="stylesheet" type="text/css" href="https://192.168.1.25/PRESENTATION/STYLE/SMT.CSS&amp;tm=1787848152343" media="only screen and (max-device-width:800px)"><link rel="stylesheet" type="text/css" href="https://192.168.1.25/PRESENTATION/STYLE/PC.CSS&amp;tm=1787848152343" media="only screen and (min-device-width:801px)"><!--[if IE ]><link rel='stylesheet' type='text/css' href='../../STYLE/PC.CSS&tm=1787848152343'><![endif]-->
+<noscript>
+<link rel='stylesheet' type='text/css' href='../../STYLE/SMT.CSS' media='only screen and (max-device-width:800px)'>
+<link rel='stylesheet' type='text/css' href='../../STYLE/PC.CSS' media='only screen and (min-device-width:801px)'>
+<!--[if IE ]>
+<link rel='stylesheet' type='text/css' href='../../STYLE/PC.CSS'>
+<![endif]-->
+</noscript>
+<title>WF-2930 Series</title>
+<script type="text/javascript" src="https://192.168.1.25/PRESENTATION/SCRIPT/MENT.JS"></script>
+</head>
+<body onload="(function(){setTimeout(function(){if(window.pageYOffset==0){window.scrollTo(0,1);}},100);})()" onunload="(function(){})()">
+<div class="wrap">
+<div class="header">
+<h1 class="font-size-14em">
+<img class="logo" src="https://192.168.1.25/PRESENTATION/IMAGE/EPSONLOGO.PNG" width="83" height="21" alt="EPSON">
+<img class="separatpr" src="https://192.168.1.25/PRESENTATION/IMAGE/SEPARATOR.PNG" width="2" height="58" alt="">
+<span class="separatpr"></span>
+<span class="header">WF-2930 Series</span>
+</h1>
+</div>
+<div class="section">
+<h2><img class="link-title" src="https://192.168.1.25/PRESENTATION/IMAGE/PRTINFO_ILL.PNG" width="48" height="48" alt="">Status urządzenia</h2>
+<table class="navi"><tbody><tr>
+<td id="tab-item-main" class="tab-item-main-on-sprtwfd" onclick="info_main_sprtwfd()">Podstawowe</td>
+<td id="tab-item-network" class="tab-item-network-off-sprtwfd" onclick="info_network_sprtwfd()">Sieć</td>
+<td id="tab-item-wfd" class="tab-item-wfd-off" onclick="info_wfd()">Wi-Fi Direct</td>
+</tr></tbody></table>
+<div id="info-main" style="display: block;">
+<div class="information-first">
+<form method="get" name="form_select_language" action="https://192.168.1.25/PRESENTATION/HTML/TOP/PRTINFO.HTML">
+<select class="list-full text" name="SEL_LANGB" onchange="return document.form_select_language.submit();">
+<option value="1">English</option>
+<option value="2">Français</option>
+<option value="4">Deutsch</option>
+<option value="3">Italiano</option>
+<option value="5">Español</option>
+<option value="6">Português</option>
+<option value="7">Nederlands</option>
+<option value="8">Русский</option>
+<option value="12">Norsk</option>
+<option value="13">Svenska</option>
+<option value="14">Suomi</option>
+<option value="15" selected="">polski</option>
+<option value="16">Čeština</option>
+<option value="17">Magyar</option>
+<option value="18">Dansk</option>
+<option value="19">Türkçe</option>
+<option value="20">Ελληνικά</option>
+<option value="21">Slovensky</option>
+<option value="22">Română</option>
+<option value="23">Україна</option>
+<option value="10">繁體中文</option>
+<option value="11">简体中文</option>
+<option value="9">한국어</option>
+</select>
+</form>
+</div>
+<div class="information">
+<fieldset id="PRT_STATUS" class="information-only clearfix"><legend class="key">Status drukarki</legend>
+<ul class="clearfix"><li><div class="preserve-white-space">Dostępny.</div></li></ul></fieldset>
+<div id="ELSE_STATUS" style="display: none;"><fieldset class="information-last clearfix"><legend class="key">Pozostałe statusy</legend>
+<ul class="clearfix"><li><noscript><div>Włącz ustawienia przeglądarki JavaScript.</div></noscript></li>
+</ul></fieldset></div>
+</div>
+<script type="text/javascript">
+<!--$N
+HideElseStatus();
+//-->$N
+</script>
+<div class="information-last clearfix">
+<ul class="inksection">
+<li class="tank">
+<div class="tank" style="background:linear-gradient(to top, #000000 0%, #000000 84%, #FFFFFF 84%, #FFFFFF 100%);"></div>
+<div class="clrname">BK</div>
+</li><!--
+--><li class="tank">
+<div class="tank" style="background:linear-gradient(to top, #FFF200 0%, #FFF200 28%, #FFFFFF 28%, #FFFFFF 100%);"></div>
+<div class="clrname">Y</div>
+</li><!--
+--><li class="tank">
+<div class="tank" style="background:linear-gradient(to top, #ED008C 0%, #ED008C 7%, #FFFFFF 7%, #FFFFFF 100%);"><img class="inkst" src="https://192.168.1.25/PRESENTATION/IMAGE/Icn_low.PNG" height="22" width="22">
+</div>
+<div class="clrname">M</div>
+</li><!--
+--><li class="tank">
+<div class="tank" style="background:linear-gradient(to top, #00AEEF 0%, #00AEEF 92%, #FFFFFF 92%, #FFFFFF 100%);"></div>
+<div class="clrname">C</div>
+</li><!--
+--><li class="tank">
+<div class="tank" style="background:linear-gradient(to top, #636311 0%, #636311 87%, #FFFFFF 87%, #FFFFFF 100%);"></div>
+<div class="mbicn"><img src="https://192.168.1.25/PRESENTATION/IMAGE/Icn_Mb.PNG" height="18" width="18"></div>
+</li>
+</ul>
+</div>
+</div>
+<div id="info-network" style="display: none;">
+<table style="border-collapse: collapse; width: 100%;">
+<tbody><tr class="item clearfix"><td class="item-key"><bdi>Nazwa urządzenia</bdi>&nbsp;:</td><td class="item-value">EPSON038F0F</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Status połączenia</bdi>&nbsp;:</td><td class="item-value">Wi-Fi-72Mbps</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Siła sygnału</bdi>&nbsp;:</td><td class="item-value">Znakomicie</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Pobierz adres IP</bdi>&nbsp;:</td><td class="item-value">Automatyczny</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Adres IP</bdi>&nbsp;:</td><td class="item-value">192.168.1.25</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Maska podsieci</bdi>&nbsp;:</td><td class="item-value">255.255.255.0</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Bramka domyślna</bdi>&nbsp;:</td><td class="item-value">192.168.1.1</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Ustawienie serwera DNS</bdi>&nbsp;:</td><td class="item-value">Automatyczny</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Główny adres DNS</bdi>&nbsp;:</td><td class="item-value">192.168.1.1</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Dodatkowy serwer DNS</bdi>&nbsp;:</td><td class="item-value">&nbsp;</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Serwer proxy</bdi>&nbsp;:</td><td class="item-value">Nie należy używać
+</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Konfiguracja Wi-Fi</bdi>&nbsp;:</td><td class="item-value">Ręczny</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>SSID</bdi>&nbsp;:</td><td class="item-value">INEA-7427</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Poziom zabezpieczeń</bdi>&nbsp;:</td><td class="item-value">WPA2-PSK(AES)</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Hasło</bdi>&nbsp;:</td><td class="item-value">**********</td></tr>
+<tr class="item-last clearfix"><td class="item-key"><bdi>Adres MAC</bdi>&nbsp;:</td><td class="item-value">F8:25:51:03:8F:0F</td></tr>
+</tbody></table>
+</div>
+<div id="info-wfd" style="display: none;">
+<table style="border-collapse: collapse; width: 100%;">
+<tbody><tr class="item clearfix"><td class="item-key"><bdi>Nazwa urządzenia</bdi>&nbsp;:</td><td class="item-value">EPSON038F0F</td></tr>
+<tr class="item clearfix"><td class="item-key"><bdi>Metoda połączenia</bdi>&nbsp;:</td><td class="item-value">Nieustawiona</td></tr>
+</tbody></table>
+</div>
+</div>
+<ul class="with-padding clearfix">
+<li id="button-latest" class="list" style="display: block;"><a class="button" href="javascript:void(0)" onclick="javascript:update(); return false;">Odśwież</a></li>
+<noscript><li class="list"><a class="button" href="./PRTINFO.HTML">Odśwież</a></li></noscript>
+<li class="list-last"><a class="button" href="https://192.168.1.25/PRESENTATION/HTML/TOP/INDEX.html">Wróć do menu gł.</a></li>
+</ul>
+<ul>
+<a class="license" target="_blank" href="https://192.168.1.25/PRESENTATION/ADVANCED/LICENSE/TOP">Licencje oprogramowania</a>
+</ul>
+</div>
+<script type="text/javascript">
+<!--
+initialize();
+//-->
+</script>
+
+<deepl-input-controller translate="no"><template shadowrootmode="open"><link rel="stylesheet" href="chrome-extension://cofdbpoegempjloogbagkncekinflcnj/build/content.css"><div dir="ltr" data-dl-surface="inputTranslator" data-dl-impl="svelte" style="visibility: initial !important;"><div class="dl-input-translation-container svelte-95aucy"><div></div></div></div></template></deepl-input-controller><div id="buffer-extension-hover-container" style="font-family: Roboto, sans-serif; display: none; position: absolute; z-index: 8675309; cursor: pointer; width: 67px;"><div id="buffer-extension-button-hover-container" style="position: relative; z-index: 8675309; width: 67px; height: 24px;"><span id="buffer-extension-hover-button" style="width: 67px; height: 24px; background-image: url(&quot;chrome-extension://noojglkidnpfjbincgijbaiedldjfbhh/buffer-hover-button.svg&quot;); background-size: 67px 24px; cursor: pointer; opacity: 0.9; display: block; position: relative; z-index: 8675309;"></span><div id="buffer-extension-button-menu" style="position: relative; z-index: 8675308; width: 140px; height: 94px; display: none; bottom: 94px; right: 75px;"><div style="font-size: 14px; width: 140px; display: block; cursor: pointer; padding: 0px 4px; color: rgb(61, 61, 61); line-height: 28px; background-color: rgba(255, 255, 255, 0.8); border-top-left-radius: 4px; border-top-right-radius: 4px; height: 4px;"></div><div id="buffer-extension-create" class="buffer-extension-hover-button" style="font-size: 14px; width: 140px; height: 28px; display: block; cursor: pointer; padding: 0px 4px; color: rgb(61, 61, 61); line-height: 28px;"><span>Create Post</span></div><div id="buffer-extension-save" class="buffer-extension-hover-button" style="font-size: 14px; width: 140px; height: 28px; display: block; cursor: pointer; padding: 0px 4px; color: rgb(61, 61, 61); line-height: 28px;"><span>Save Idea</span></div><div style="font-size: 14px; width: 140px; display: block; cursor: pointer; padding: 0px 4px; color: rgb(61, 61, 61); line-height: 28px; background-color: rgba(255, 255, 255, 0.8); border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; height: 4px;"></div><style>.buffer-extension-hover-button { background-color:rgba(255, 255, 255, 0.8); } .buffer-extension-hover-button span { display:block; padding: 0 4px; border-radius: 4px 4px 4px 4px; -webkit-border-radius: 4px 4px 4px 4px; -moz-border-radius: 4px 4px 4px 4px; } .buffer-extension-hover-button:hover span { background-color:#F5F5F5; }</style></div></div></div></body></html>

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -17,6 +17,14 @@ ALL_FIXTURES = sorted(
 # ---- Per-file expectations (only list what you care to assert) ----
 # Any keys omitted will be skipped (defaults handle the rest).
 EXPECTATIONS: dict[str, dict[str, Any]] = {
+    "WF-2930.html": {
+        "inks": {
+            "BK": 84,
+            "Y": 28,
+            "M": 7,
+            "C": 92,
+        },
+    },
     "ET-8500.html": {
         "name": "EPSON0C9E89",
         "model": "Epson ET-8500 Series",


### PR DESCRIPTION
## Description

Some Epson printers represent ink levels using CSS `linear-gradient()` styles instead of an image height.

The parser currently checks the `<img>` height before checking the CSS gradient. On printers such as the WF-2930, a low-ink warning icon can be present inside the ink tank, causing the icon's image height to be interpreted as the ink level.

This changes the parsing order to:

1. Parse the ink level from the CSS `linear-gradient()` when available.
2. Fall back to the tank's CSS `height`.
3. Fall back to the `<img>` height for printers that use that representation.

## Testing

Added a real-world WF-2930 HTML fixture with the expected ink levels:

- BK: 84%
- Y: 28%
- M: 7%
- C: 92%

All tests pass:

`48 passed`

The fixture is from the printer's HTML output.