### PR TITLE
Add state_class to percentage sensors for long-term statistics

### DIFF
--- a/custom_components/epson_workforce/sensor.py
+++ b/custom_components/epson_workforce/sensor.py
@@ -25,48 +25,56 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         name="Ink level Black",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
         key="ink_pb",
         name="Ink level Photoblack",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
         key="ink_gy",
         name="Ink level Gray",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
         key="ink_m",
         name="Ink level Magenta",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
         key="ink_c",
         name="Ink level Cyan",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
         key="ink_y",
         name="Ink level Yellow",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
         key="ink_lc",
         name="Ink level Light Cyan",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(  # type: ignore[call-arg]
         key="ink_lm",
         name="Ink level Light Magenta",
         icon="mdi:water",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     # --- Maintenance ---
     SensorEntityDescription(  # type: ignore[call-arg]
@@ -74,6 +82,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         name="Cleaning level",
         icon="mdi:broom",
         native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     # --- Status ---
     SensorEntityDescription(  # type: ignore[call-arg]

--- a/tests/test_supplemental.py
+++ b/tests/test_supplemental.py
@@ -163,3 +163,47 @@ class TestEntityRegistryEnabledDefault:
         classified = self.ENABLED_BY_DEFAULT | self.DISABLED_BY_DEFAULT
         assert not (all_keys - classified), f"Unclassified: {all_keys - classified}"
         assert not (self.ENABLED_BY_DEFAULT & self.DISABLED_BY_DEFAULT)
+
+
+# ---------------------------------------------------------------------------
+# state_class
+# ---------------------------------------------------------------------------
+
+
+class TestSensorStateClass:
+    """Percentage sensors need a state class to get long-term statistics."""
+
+    PERCENTAGE_KEYS = {
+        "ink_bk",
+        "ink_pb",
+        "ink_gy",
+        "ink_m",
+        "ink_c",
+        "ink_y",
+        "ink_lc",
+        "ink_lm",
+        "clean",
+    }
+
+    def test_percentage_sensors_are_measurements(self):
+        from homeassistant.components.sensor import SensorStateClass
+
+        from custom_components.epson_workforce.sensor import SENSOR_TYPES
+
+        for desc in SENSOR_TYPES:
+            if desc.key in self.PERCENTAGE_KEYS:
+                assert (
+                    desc.state_class == SensorStateClass.MEASUREMENT
+                ), f"{desc.key!r} should be a measurement"
+
+    def test_percentage_keys_match_sensor_types(self):
+        from homeassistant.const import PERCENTAGE
+
+        from custom_components.epson_workforce.sensor import SENSOR_TYPES
+
+        actual = {
+            desc.key
+            for desc in SENSOR_TYPES
+            if desc.native_unit_of_measurement == PERCENTAGE
+        }
+        assert actual == self.PERCENTAGE_KEYS


### PR DESCRIPTION
Closes #71.

The eight ink level sensors and the maintenance box sensor (`clean`) report a percentage but declared no `state_class`, so Home Assistant kept only short-term recorder history for them and never compiled long-term statistics. Ink consumption therefore can't be graphed beyond `recorder.purge_keep_days`, and the sensors don't show up in a `statistics-graph` card.

`MEASUREMENT` is the correct class here: the value drops while printing and jumps back up when a cartridge is replaced, so `TOTAL_INCREASING` would be wrong. No `device_class` is set — Home Assistant has no ink/consumable device class and `BATTERY` would be semantically wrong.

The page, copy and scan counters in the same table already declare `TOTAL_INCREASING`, so this just fills in the descriptions that were missed.

### Changes

- `sensor.py`: `state_class=SensorStateClass.MEASUREMENT` on the nine descriptions that use `native_unit_of_measurement=PERCENTAGE` (`ink_bk`, `ink_pb`, `ink_gy`, `ink_m`, `ink_c`, `ink_y`, `ink_lc`, `ink_lm`, `clean`). `SensorStateClass` was already imported.
- `tests/test_supplemental.py`: a `TestSensorStateClass` class asserting that every percentage sensor is a `MEASUREMENT`, plus a second test asserting the set of `PERCENTAGE` sensors matches the keys under test — so a newly added ink colour can't silently skip the state class.

### Verification

`ruff check custom_components` and `ruff format --check` both pass.

Full suite run in a `python:3.13` container against this repo's exact `requirements-test.txt` (the same set CI installs):

```
Python 3.13.15
50 passed in 0.67s
```

The two added tests are collected and pass:

```
tests/test_supplemental.py::TestSensorStateClass::test_percentage_sensors_are_measurements PASSED
tests/test_supplemental.py::TestSensorStateClass::test_percentage_keys_match_sensor_types  PASSED
```

The Actions runs on this PR sit at `action_required` — as a first-time contributor here they need your approval before they'll execute.

Tested against an Epson Expression Home XP-4200 on Home Assistant 2026.9.0 with integration v0.9.1: after the change the five sensors that printer exposes get statistics rows and can be graphed.

### Note for existing users

This only affects statistics going forward — it does not backfill history from the short-term recorder data.
